### PR TITLE
Refatorar: adicionar análise emocional de feedbacks e melhorar a exibição de insights, incluindo clusters emocionais e termômetro de sentimentos.

### DIFF
--- a/pages/user/feedbacks/insights/feedbackInsightsReport.tsx
+++ b/pages/user/feedbacks/insights/feedbackInsightsReport.tsx
@@ -1,22 +1,72 @@
 import { useEffect, useState } from 'react';
 import {
+  ServiceGetFeedbackAnalysis,
   ServiceGetFeedbackInsightsReport,
   ServiceRunFeedbackIAAnalysis,
 } from 'src/services/serviceFeedbacks';
-import type { FeedbackInsightsReport } from 'lib/interfaces/user/feedback';
+import type {
+  FeedbackAnalysisSummary,
+  FeedbackInsightsReport,
+} from 'lib/interfaces/user/feedback';
+
+function getMoodFromSummary(summary: FeedbackAnalysisSummary | null) {
+  if (!summary || summary.totalAnalyzed === 0) {
+    return {
+      label: 'Sem dados suficientes',
+      tone: 'neutral' as const,
+      description:
+        'Ainda não há feedbacks suficientes analisados pela IA para determinar o clima emocional.',
+    };
+  }
+
+  const { positive, neutral, negative } = summary.sentiments;
+  const max = Math.max(positive, neutral, negative);
+
+  if (max === positive) {
+    return {
+      label: 'Clima Positivo',
+      tone: 'positive' as const,
+      description:
+        'A maioria dos feedbacks recentes está positiva, indicando satisfação geral com a experiência.',
+    };
+  }
+
+  if (max === negative) {
+    return {
+      label: 'Clima de Atenção',
+      tone: 'negative' as const,
+      description:
+        'Há concentração de feedbacks negativos, sugerindo pontos críticos que precisam de ação imediata.',
+    };
+  }
+
+  return {
+    label: 'Clima Neutro',
+    tone: 'neutral' as const,
+    description:
+      'Os feedbacks estão balanceados entre elogios e reclamações, apontando espaço claro para melhoria.',
+  };
+}
 
 export default function FeedbacksInsightsReport() {
   const [report, setReport] = useState<FeedbackInsightsReport | null>(null);
+  const [summary, setSummary] = useState<FeedbackAnalysisSummary | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
 
-  const loadReport = async () => {
+  const loadData = async () => {
     try {
       setLoading(true);
       setError(null);
-      const data = await ServiceGetFeedbackInsightsReport();
-      setReport(data);
+
+      const [reportData, analysisData] = await Promise.all([
+        ServiceGetFeedbackInsightsReport(),
+        ServiceGetFeedbackAnalysis(),
+      ]);
+
+      setReport(reportData);
+      setSummary(analysisData.summary);
     } catch (err) {
       console.error('Erro ao carregar relatório de insights (IA):', err);
       setError('Erro ao carregar relatório de insights');
@@ -26,7 +76,7 @@ export default function FeedbacksInsightsReport() {
   };
 
   useEffect(() => {
-    void loadReport();
+    void loadData();
   }, []);
 
   const handleRefreshClick = async () => {
@@ -38,7 +88,7 @@ export default function FeedbacksInsightsReport() {
       await ServiceRunFeedbackIAAnalysis();
 
       // Recarrega o relatório após a atualização
-      await loadReport();
+      await loadData();
     } catch (err) {
       console.error('Erro ao atualizar insights com IA:', err);
       setError('Erro ao atualizar insights com IA');
@@ -110,9 +160,45 @@ export default function FeedbacksInsightsReport() {
       ? new Date(report.updatedAt).toLocaleString('pt-BR')
       : null;
 
+  const mood = getMoodFromSummary(summary);
+
+  const total = summary?.totalAnalyzed ?? 0;
+  const positivePct =
+    total > 0 ? Math.round((summary!.sentiments.positive / total) * 100) : 0;
+  const neutralPct =
+    total > 0 ? Math.round((summary!.sentiments.neutral / total) * 100) : 0;
+  const negativePct =
+    total > 0 ? Math.round((summary!.sentiments.negative / total) * 100) : 0;
+
+  const toneColors: Record<
+    'positive' | 'neutral' | 'negative',
+    { border: string; bg: string; text: string }
+  > = {
+    positive: {
+      border: 'border-emerald-500/60',
+      bg: 'bg-emerald-500/10',
+      text: 'text-emerald-300',
+    },
+    neutral: {
+      border: 'border-amber-500/60',
+      bg: 'bg-amber-500/10',
+      text: 'text-amber-300',
+    },
+    negative: {
+      border: 'border-rose-500/60',
+      bg: 'bg-rose-500/10',
+      text: 'text-rose-300',
+    },
+  };
+
+  const toneKey = mood.tone === 'positive' || mood.tone === 'negative'
+    ? mood.tone
+    : 'neutral';
+  const tone = toneColors[toneKey];
+
   return (
     <div className="font-inter space-y-6">
-      <div className="relative overflow-hidden rounded-2xl border border-neutral-800 bg-neutral-900/60 p-6 glass-card">
+      <div className="relative overflow-hidden rounded-2xl border border-neutral-800 bg-neutral-900/60 p-6 glass-card space-y-6">
         <div className="flex justify-between items-start gap-4 mb-4">
           <div>
             <h2 className="text-lg font-semibold text-[var(--text-primary)] mb-1">
@@ -139,6 +225,45 @@ export default function FeedbacksInsightsReport() {
               {refreshing ? 'Atualizando...' : 'Atualizar insights com IA'}
             </button>
           </div>
+        </div>
+
+        {/* Clima emocional geral */}
+        <div
+          className={`rounded-2xl border ${tone.border} ${tone.bg} p-4 flex flex-col md:flex-row md:items-center md:justify-between gap-4`}>
+          <div className="space-y-1">
+            <div className={`text-xs uppercase tracking-wide ${tone.text}`}>
+              Clima emocional geral
+            </div>
+            <div className={`text-xl font-semibold ${tone.text}`}>
+              {mood.label}
+            </div>
+            <p className="text-xs text-[var(--text-muted)] max-w-xl">
+              {mood.description}
+            </p>
+          </div>
+          {summary && summary.totalAnalyzed > 0 && (
+            <div className="w-full md:w-1/2 space-y-2">
+              <div className="w-full h-2 rounded-full bg-neutral-900 overflow-hidden flex">
+                <div
+                  style={{ width: `${positivePct}%` }}
+                  className="h-full bg-emerald-500/70"
+                />
+                <div
+                  style={{ width: `${neutralPct}%` }}
+                  className="h-full bg-amber-500/70"
+                />
+                <div
+                  style={{ width: `${negativePct}%` }}
+                  className="h-full bg-rose-500/70"
+                />
+              </div>
+              <div className="flex justify-between text-[10px] text-[var(--text-muted)]">
+                <span>Positivos: {positivePct}%</span>
+                <span>Neutros: {neutralPct}%</span>
+                <span>Negativos: {negativePct}%</span>
+              </div>
+            </div>
+          )}
         </div>
 
         {report?.summary && report.summary.trim().length > 0 && (

--- a/pages/user/feedbacks/insights/feedbacksInsightsEmotional.tsx
+++ b/pages/user/feedbacks/insights/feedbacksInsightsEmotional.tsx
@@ -1,7 +1,261 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ServiceGetFeedbackAnalysis } from 'src/services/serviceFeedbacks';
+import type {
+  FeedbackAnalysisItem,
+  FeedbackAnalysisSummary,
+} from 'lib/interfaces/user/feedback';
+
+type EmotionalCluster = {
+  title: string;
+  description: string;
+  tone: 'positive' | 'neutral' | 'negative';
+  items: FeedbackAnalysisItem[];
+};
+
 export default function FeedbacksInsigthsEmotional() {
+  const [items, setItems] = useState<FeedbackAnalysisItem[]>([]);
+  const [summary, setSummary] = useState<FeedbackAnalysisSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await ServiceGetFeedbackAnalysis();
+        if (!mounted) return;
+        setItems(response.items);
+        setSummary(response.summary);
+      } catch (err) {
+        console.error(
+          'Erro ao carregar insights emocionais de feedbacks (IA):',
+          err,
+        );
+        if (!mounted) return;
+        setError('Erro ao carregar insights emocionais');
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const clusters = useMemo<EmotionalCluster[]>(() => {
+    if (!items.length) return [];
+
+    const mostNegative = [...items]
+      .filter((i) => i.sentiment === 'negative')
+      .sort((a, b) => (a.rating ?? 3) - (b.rating ?? 3))
+      .slice(0, 5);
+
+    const mostPositive = [...items]
+      .filter((i) => i.sentiment === 'positive')
+      .sort((a, b) => (b.rating ?? 3) - (a.rating ?? 3))
+      .slice(0, 5);
+
+    const mostNeutral = [...items]
+      .filter((i) => i.sentiment === 'neutral')
+      .slice(0, 5);
+
+    const clustersOut: EmotionalCluster[] = [];
+
+    if (mostPositive.length > 0) {
+      clustersOut.push({
+        title: 'Momentos que encantam',
+        description:
+          'Feedbacks onde os clientes demonstram entusiasmo e reconhecimento pelo que sua empresa faz bem.',
+        tone: 'positive',
+        items: mostPositive,
+      });
+    }
+
+    if (mostNegative.length > 0) {
+      clustersOut.push({
+        title: 'Pontos de dor mais intensos',
+        description:
+          'Mensagens com maior carga negativa, que indicam frustrações claras na jornada do cliente.',
+        tone: 'negative',
+        items: mostNegative,
+      });
+    }
+
+    if (mostNeutral.length > 0) {
+      clustersOut.push({
+        title: 'Feedbacks neutros e ambivalentes',
+        description:
+          'Opiniões que não são claramente positivas ou negativas, mas revelam oportunidades sutis de melhoria.',
+        tone: 'neutral',
+        items: mostNeutral,
+      });
+    }
+
+    return clustersOut;
+  }, [items]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="text-lg text-[var(--text-primary)]">
+          Carregando insights emocionais...
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="text-red-400">{error}</div>
+      </div>
+    );
+  }
+
+  if (!summary || summary.totalAnalyzed === 0) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="text-[var(--text-muted)]">
+          Ainda não há feedbacks suficientes analisados para gerar insights
+          emocionais.
+        </div>
+      </div>
+    );
+  }
+
+  const total = summary.totalAnalyzed;
+  const positivePct = Math.round(
+    (summary.sentiments.positive / total) * 100,
+  );
+  const neutralPct = Math.round((summary.sentiments.neutral / total) * 100);
+  const negativePct = Math.round(
+    (summary.sentiments.negative / total) * 100,
+  );
+
   return (
-    <div>
-      <div></div>
+    <div className="font-inter space-y-6">
+      {/* Termômetro emocional */}
+      <div className="relative overflow-hidden rounded-2xl border border-neutral-800 bg-neutral-900/60 p-6 glass-card space-y-4">
+        <h2 className="text-lg font-semibold text-[var(--text-primary)]">
+          Termômetro emocional dos clientes
+        </h2>
+        <p className="text-sm text-[var(--text-muted)] max-w-2xl">
+          Visualização da intensidade emocional dos feedbacks, destacando onde
+          os clientes estão mais satisfeitos e onde sentem maior frustração.
+        </p>
+
+        <div className="w-full h-3 rounded-full bg-neutral-800 overflow-hidden flex">
+          <div
+            style={{ width: `${positivePct}%` }}
+            className="h-full bg-emerald-500/70"
+          />
+          <div
+            style={{ width: `${neutralPct}%` }}
+            className="h-full bg-amber-500/70"
+          />
+          <div
+            style={{ width: `${negativePct}%` }}
+            className="h-full bg-rose-500/70"
+          />
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm mt-2">
+          <div>
+            <div className="text-xs text-[var(--text-muted)] uppercase tracking-wide">
+              Positivos
+            </div>
+            <div className="text-xl font-semibold text-emerald-300">
+              {summary.sentiments.positive} ({positivePct}%)
+            </div>
+          </div>
+          <div>
+            <div className="text-xs text-[var(--text-muted)] uppercase tracking-wide">
+              Neutros
+            </div>
+            <div className="text-xl font-semibold text-amber-300">
+              {summary.sentiments.neutral} ({neutralPct}%)
+            </div>
+          </div>
+          <div>
+            <div className="text-xs text-[var(--text-muted)] uppercase tracking-wide">
+              Negativos
+            </div>
+            <div className="text-xl font-semibold text-rose-300">
+              {summary.sentiments.negative} ({negativePct}%)
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Clusters emocionais */}
+      <div className="relative overflow-hidden rounded-2xl border border-neutral-800 bg-neutral-900/60 p-6 glass-card space-y-6">
+        <h3 className="text-base font-semibold text-[var(--text-primary)]">
+          Momentos emocionais que mais se repetem
+        </h3>
+        <p className="text-sm text-[var(--text-muted)] max-w-2xl mb-2">
+          Explore exemplos reais de feedbacks que representam emoções mais
+          fortes dos seus clientes — tanto positivas quanto negativas.
+        </p>
+
+        {clusters.length === 0 ? (
+          <div className="text-sm text-[var(--text-muted)]">
+            Ainda não há clusters emocionais suficientes para exibir.
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {clusters.map((cluster) => (
+              <div
+                key={cluster.title}
+                className="border border-neutral-800 rounded-xl bg-neutral-900/80 p-4 space-y-3">
+                <div>
+                  <h4 className="text-sm font-semibold text-[var(--text-primary)] mb-1">
+                    {cluster.title}
+                  </h4>
+                  <p className="text-xs text-[var(--text-muted)]">
+                    {cluster.description}
+                  </p>
+                </div>
+
+                <div className="space-y-2 max-h-64 overflow-y-auto pr-1">
+                  {cluster.items.map((item) => (
+                    <div
+                      key={item.id}
+                      className="border border-neutral-800 rounded-lg bg-neutral-950/60 p-3 space-y-1">
+                      <div className="flex items-center justify-between text-[10px] text-[var(--text-muted)]">
+                        <span>
+                          {new Date(item.created_at).toLocaleDateString(
+                            'pt-BR',
+                            {
+                              day: '2-digit',
+                              month: '2-digit',
+                              year: '2-digit',
+                            },
+                          )}
+                        </span>
+                        <span>
+                          Rating: {item.rating ?? '—'} ·{' '}
+                          {item.sentiment === 'positive'
+                            ? 'Positivo'
+                            : item.sentiment === 'negative'
+                            ? 'Negativo'
+                            : 'Neutro'}
+                        </span>
+                      </div>
+                      <p className="text-xs text-[var(--text-primary)] whitespace-pre-wrap">
+                        {item.message}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an emotional insights page (thermometer + clusters) and enhances the report to fetch AI analysis and display overall emotional climate with sentiment distribution.
> 
> - **UI/Insights**:
>   - **New emotional insights page** (`pages/user/feedbacks/insights/feedbacksInsightsEmotional.tsx`):
>     - Fetches AI analysis (`ServiceGetFeedbackAnalysis`) with loading/error states.
>     - Displays sentiment “thermometer” with positive/neutral/negative counts and percentages.
>     - Shows clustered examples of feedbacks (positive, negative, neutral) with metadata.
>   - **Enhanced report** (`pages/user/feedbacks/insights/feedbackInsightsReport.tsx`):
>     - Loads report and analysis in parallel via `loadData()` using `ServiceGetFeedbackInsightsReport` + `ServiceGetFeedbackAnalysis`.
>     - Adds computed overall emotional mood (positive/neutral/negative) with descriptive card and sentiment distribution bar.
>     - Refresh action now reprocesses with `ServiceRunFeedbackIAAnalysis()` and reloads combined data.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 542522336f631cd9cfd1012b1e7b34ba4aecb13b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->