### PR TITLE
Implementation fields dinamic form feedback

### DIFF
--- a/components/public/forms/fields/fieldsQRCode/fieldDynamicQuestions.tsx
+++ b/components/public/forms/fields/fieldsQRCode/fieldDynamicQuestions.tsx
@@ -1,0 +1,55 @@
+import type { FeedbackAnswerValue } from 'lib/interfaces/contracts/qrcode.contract';
+import type { FieldDynamicQuestionsProps } from './ui.types';
+
+const ANSWER_OPTIONS: Array<{ value: FeedbackAnswerValue; label: string }> = [
+  { value: 'PESSIMO', label: 'Péssimo' },
+  { value: 'RUIM', label: 'Ruim' },
+  { value: 'MEDIANA', label: 'Mediana' },
+  { value: 'BOA', label: 'Boa' },
+  { value: 'OTIMA', label: 'Ótima' },
+];
+
+export default function FieldDynamicQuestions({
+  questions,
+  answers,
+  onAnswerChange,
+}: FieldDynamicQuestionsProps) {
+  if (!questions.length) {
+    return null;
+  }
+
+  const sortedQuestions = [...questions].sort(
+    (left, right) => left.question_order - right.question_order,
+  );
+
+  return (
+    <div className="space-y-4">
+      {sortedQuestions.map((question) => {
+        const selectedAnswer =
+          answers.find((answer) => answer.question_id === question.id)?.answer_value ?? '';
+
+        return (
+          <div key={question.id}>
+            <label className="mb-2 block text-sm font-medium text-(--text-primary) font-work-sans">
+              {question.question_order}. {question.question_text}
+            </label>
+            <select
+              value={selectedAnswer}
+              onChange={(event) =>
+                onAnswerChange(question.id, event.target.value as FeedbackAnswerValue)
+              }
+              className="w-full rounded-lg border border-(--quaternary-color)/14 bg-(--seventh-color) px-3 py-3 text-(--text-primary) outline-none focus:border-(--primary-color) focus:ring-2 focus:ring-(--primary-color)/20 font-work-sans"
+            >
+              <option value="">Selecione uma opção</option>
+              {ANSWER_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/public/forms/fields/fieldsQRCode/fieldDynamicQuestions.tsx
+++ b/components/public/forms/fields/fieldsQRCode/fieldDynamicQuestions.tsx
@@ -9,6 +9,14 @@ const ANSWER_OPTIONS: Array<{ value: FeedbackAnswerValue; label: string }> = [
   { value: 'OTIMA', label: 'Ótima' },
 ];
 
+const ANSWER_HELPER: Record<FeedbackAnswerValue, string> = {
+  PESSIMO: 'Muito abaixo do esperado',
+  RUIM: 'Abaixo do esperado',
+  MEDIANA: 'Atendeu parcialmente',
+  BOA: 'Boa experiência geral',
+  OTIMA: 'Excelente experiência',
+};
+
 export default function FieldDynamicQuestions({
   questions,
   answers,
@@ -23,30 +31,52 @@ export default function FieldDynamicQuestions({
   );
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       {sortedQuestions.map((question) => {
         const selectedAnswer =
           answers.find((answer) => answer.question_id === question.id)?.answer_value ?? '';
 
         return (
-          <div key={question.id}>
-            <label className="mb-2 block text-sm font-medium text-(--text-primary) font-work-sans">
+          <div
+            key={question.id}
+            className="rounded-xl border border-(--quaternary-color)/15 bg-(--seventh-color)/70 p-3"
+          >
+            <p className="mb-2 text-sm font-medium text-(--text-primary) font-work-sans">
               {question.question_order}. {question.question_text}
-            </label>
-            <select
-              value={selectedAnswer}
-              onChange={(event) =>
-                onAnswerChange(question.id, event.target.value as FeedbackAnswerValue)
-              }
-              className="w-full rounded-lg border border-(--quaternary-color)/14 bg-(--seventh-color) px-3 py-3 text-(--text-primary) outline-none focus:border-(--primary-color) focus:ring-2 focus:ring-(--primary-color)/20 font-work-sans"
+            </p>
+
+            <div
+              className="flex snap-x gap-2 overflow-x-auto pb-1 sm:flex-wrap sm:overflow-x-visible"
+              role="radiogroup"
+              aria-label={`Pergunta ${question.question_order}`}
             >
-              <option value="">Selecione uma opção</option>
-              {ANSWER_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
+              {ANSWER_OPTIONS.map((option) => {
+                const isSelected = selectedAnswer === option.value;
+
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    role="radio"
+                    aria-checked={isSelected}
+                    onClick={() => onAnswerChange(question.id, option.value)}
+                    className={`min-w-[108px] shrink-0 rounded-full border px-3 py-2 text-sm font-semibold transition-all duration-200 font-work-sans sm:min-w-0 ${
+                      isSelected
+                        ? 'border-(--primary-color) bg-(--primary-color)/15 text-(--text-primary) shadow-[0_0_0_1px_var(--primary-color)]'
+                        : 'border-(--quaternary-color)/20 bg-(--eighth-color)/80 text-(--text-secondary) hover:border-(--primary-color)/45 hover:bg-(--primary-color)/8 hover:text-(--text-primary)'
+                    }`}
+                  >
+                    {option.label}
+                  </button>
+                );
+              })}
+            </div>
+
+            <p className="mt-2 text-xs text-(--text-secondary) font-work-sans">
+              {selectedAnswer
+                ? ANSWER_HELPER[selectedAnswer as FeedbackAnswerValue]
+                : 'Toque em uma opção para responder'}
+            </p>
           </div>
         );
       })}

--- a/components/public/forms/fields/fieldsQRCode/fieldRating.tsx
+++ b/components/public/forms/fields/fieldsQRCode/fieldRating.tsx
@@ -12,7 +12,7 @@ export default function FieldRating({ rating, onRatingChange }: FieldRatingProps
   return (
     <div>
       <label className="font-work-sans block text-sm font-medium text-(--text-primary) mb-3">
-        Como você avalia nossa experiência?
+        Como você avalia sua experiência?
       </label>
       <div className="flex justify-center gap-2">
         {[1, 2, 3, 4, 5].map((star) => (

--- a/components/public/forms/fields/fieldsQRCode/ui.types.ts
+++ b/components/public/forms/fields/fieldsQRCode/ui.types.ts
@@ -1,6 +1,8 @@
 import type {
+  FeedbackAnswerValue,
   CustomerData,
   FeedbackData,
+  FeedbackQuestionPublic,
 } from 'lib/interfaces/contracts/qrcode.contract';
 
 /**
@@ -40,16 +42,28 @@ export interface FieldRatingProps {
 }
 
 /**
+ * Props do bloco de perguntas dinâmicas do feedback.
+ * Usado em: components/public/forms/fields/fieldsQRCode/fieldDynamicQuestions.tsx.
+ */
+export interface FieldDynamicQuestionsProps {
+  questions: FeedbackQuestionPublic[];
+  answers: FeedbackData['answers'];
+  onAnswerChange: (questionId: string, answerValue: FeedbackAnswerValue) => void;
+}
+
+/**
  * Props do formulário completo de feedback por QR Code.
  * Usado em: components/public/forms/formQRCodeFeedback.tsx.
  */
 export interface FormQRCodeFeedbackProps {
   formData: FeedbackData;
+  questions: FeedbackQuestionPublic[];
   customerData: CustomerData;
   showOptionalFields: boolean;
   error: string;
   isSubmitting: boolean;
   onFormDataChange: (data: Partial<FeedbackData>) => void;
+  onAnswerChange: (questionId: string, answerValue: FeedbackAnswerValue) => void;
   onCustomerDataChange: (
     field: keyof CustomerData,
     value: string | undefined,

--- a/components/public/forms/formQRCodeFeedback.tsx
+++ b/components/public/forms/formQRCodeFeedback.tsx
@@ -1,4 +1,5 @@
 import FieldRating from './fields/fieldsQRCode/fieldRating';
+import FieldDynamicQuestions from './fields/fieldsQRCode/fieldDynamicQuestions';
 import FieldMessage from './fields/fieldsQRCode/fieldMessage';
 import FieldCustomerName from './fields/fieldsQRCode/fieldCustomerName';
 import FieldCustomerEmail from './fields/fieldsQRCode/fieldCustomerEmail';
@@ -8,11 +9,13 @@ import { FaSpinner } from 'react-icons/fa6';
 
 export default function FormQRCodeFeedback({
   formData,
+  questions,
   customerData,
   showOptionalFields,
   error,
   isSubmitting,
   onFormDataChange,
+  onAnswerChange,
   onCustomerDataChange,
   onToggleOptionalFields,
   onSubmit,
@@ -22,6 +25,12 @@ export default function FormQRCodeFeedback({
       <FieldRating
         rating={formData.rating}
         onRatingChange={(rating) => onFormDataChange({ rating })}
+      />
+
+      <FieldDynamicQuestions
+        questions={questions}
+        answers={formData.answers}
+        onAnswerChange={onAnswerChange}
       />
 
       <FieldMessage

--- a/components/user/pages/dashboard/SectionLatestFeedbacks.tsx
+++ b/components/user/pages/dashboard/SectionLatestFeedbacks.tsx
@@ -4,6 +4,14 @@ import { truncateMessage } from 'lib/utils/truncateText';
 import { formatDateTime } from 'lib/utils/FormatDate';
 import type { LatestFeedbacksProps } from './ui.types';
 
+const ANSWER_LABEL: Record<string, string> = {
+  PESSIMO: 'Péssimo',
+  RUIM: 'Ruim',
+  MEDIANA: 'Mediana',
+  BOA: 'Boa',
+  OTIMA: 'Ótima',
+};
+
 export default function SectionLatestFeedbacks({
   latestFeedbacks,
   latestLimit,
@@ -51,6 +59,19 @@ export default function SectionLatestFeedbacks({
               <p className="text-sm leading-relaxed text-(--text-primary)">
                 {truncateMessage(feedback.message)}
               </p>
+              {(feedback.feedback_question_answers ?? []).length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {(feedback.feedback_question_answers ?? []).slice(0, 3).map((answer, index) => (
+                    <span
+                      key={`${feedback.id}-latest-question-answer-${answer.question_id}`}
+                      title={answer.question_text_snapshot}
+                      className="rounded-full border border-(--quaternary-color)/15 bg-(--bg-secondary) px-2.5 py-1 text-xs text-(--text-secondary)"
+                    >
+                      {index + 1}. {ANSWER_LABEL[answer.answer_value] ?? answer.answer_value}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
               {feedback.tracked_devices?.customer ? (
                 <p className="text-xs text-(--text-tertiary)">
                   Cliente:{' '}

--- a/components/user/pages/feedbacks/feedbackCard.tsx
+++ b/components/user/pages/feedbacks/feedbackCard.tsx
@@ -1,5 +1,13 @@
 import type { FeedbackCardProps } from './ui.types';
 
+const ANSWER_LABEL: Record<string, string> = {
+  PESSIMO: 'Péssimo',
+  RUIM: 'Ruim',
+  MEDIANA: 'Mediana',
+  BOA: 'Boa',
+  OTIMA: 'Ótima',
+};
+
 export default function FeedbackCard({ feedback, onClick }: FeedbackCardProps) {
   const catalogItem = Array.isArray(feedback.collection_points?.catalog_items)
     ? (feedback.collection_points?.catalog_items[0] ?? null)
@@ -17,6 +25,7 @@ export default function FeedbackCard({ feedback, onClick }: FeedbackCardProps) {
   const renderStars = (rating: number) => {
     return Array.from({ length: 5 }, (_, index) => (
       <span
+        key={`feedback-star-${index}`}
         className={`text-lg ${index < rating ? 'text-amber-300' : 'text-(--text-tertiary)'
           }`}>
         ★
@@ -70,6 +79,8 @@ export default function FeedbackCard({ feedback, onClick }: FeedbackCardProps) {
       ? (feedback.collection_points?.name || '').replace(/^QR Code\s*-\s*.+$/, 'QR Code')
       : (feedback.collection_points?.name || 'N/A');
 
+  const questionAnswers = feedback.feedback_question_answers ?? [];
+
   return (
     <div
       className={`font-work-sans relative overflow-hidden rounded-2xl border border-(--quaternary-color)/10 bg-gradient-to-br from-(--bg-secondary) to-(--sixth-color) p-6 glass-card ${onClick
@@ -103,6 +114,20 @@ export default function FeedbackCard({ feedback, onClick }: FeedbackCardProps) {
           {feedback.message}
         </p>
       </div>
+
+      {questionAnswers.length > 0 && (
+        <div className="mb-5 flex flex-wrap gap-2">
+          {questionAnswers.slice(0, 3).map((answer, index) => (
+            <span
+              key={`${feedback.id}-question-answer-${answer.question_id}`}
+              title={answer.question_text_snapshot}
+              className="rounded-full border border-(--quaternary-color)/15 bg-(--seventh-color) px-3 py-1 text-xs text-(--text-secondary)"
+            >
+              {index + 1}. {ANSWER_LABEL[answer.answer_value] ?? answer.answer_value}
+            </span>
+          ))}
+        </div>
+      )}
 
       {/* Informações adicionais */}
       <div className="flex justify-between items-center text-sm">

--- a/components/user/pages/feedbacksAll/FeedbackDetailsModal.tsx
+++ b/components/user/pages/feedbacksAll/FeedbackDetailsModal.tsx
@@ -2,6 +2,14 @@ import type { FeedbackDetailsModalProps } from './ui.types';
 
 import { formatDateTime } from 'lib/utils/FormatDate';
 
+const ANSWER_LABEL: Record<string, string> = {
+  PESSIMO: 'Péssimo',
+  RUIM: 'Ruim',
+  MEDIANA: 'Mediana',
+  BOA: 'Boa',
+  OTIMA: 'Ótima',
+};
+
 export default function FeedbackDetailsModal({
   selectedFeedback,
   onClose,
@@ -32,6 +40,8 @@ export default function FeedbackDetailsModal({
     selectedFeedback.collection_points?.type === 'QR_CODE'
       ? (selectedFeedback.collection_points?.name || '').replace(/^QR Code\s*-\s*.+$/, 'QR Code')
       : (selectedFeedback.collection_points?.name || 'N/A');
+
+  const questionAnswers = selectedFeedback.feedback_question_answers ?? [];
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4" onClick={onClose}>
@@ -96,6 +106,31 @@ export default function FeedbackDetailsModal({
             ) : (
               <div className="text-sm text-(--text-tertiary)">
                 Nenhuma informação de ponto de coleta.
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-2 rounded-xl border border-(--quaternary-color)/10 bg-(--seventh-color) p-4">
+            <h3 className="text-sm font-montserrat font-medium text-(--text-secondary)">Perguntas Dinâmicas</h3>
+            {questionAnswers.length > 0 ? (
+              <div className="space-y-2">
+                {questionAnswers.slice(0, 3).map((answer, index) => (
+                  <div
+                    key={`${selectedFeedback.id}-question-answer-${answer.question_id}`}
+                    className="rounded-lg border border-(--quaternary-color)/10 bg-(--bg-secondary) px-3 py-2"
+                  >
+                    <p className="text-xs text-(--text-tertiary)">
+                      {index + 1}. {answer.question_text_snapshot}
+                    </p>
+                    <p className="mt-1 text-sm font-medium text-(--text-primary)">
+                      {ANSWER_LABEL[answer.answer_value] ?? answer.answer_value}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="text-sm text-(--text-tertiary)">
+                Este feedback não possui respostas das perguntas dinâmicas.
               </div>
             )}
           </div>

--- a/components/user/pages/feedbacksInsightsReport/InsightsReportErrorState.tsx
+++ b/components/user/pages/feedbacksInsightsReport/InsightsReportErrorState.tsx
@@ -1,18 +1,112 @@
 import type { InsightsReportErrorStateProps } from './ui.types';
 
+const WarningIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="h-7 w-7"
+    aria-hidden="true"
+  >
+    <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+    <line x1="12" y1="9" x2="12" y2="13" />
+    <line x1="12" y1="17" x2="12.01" y2="17" />
+  </svg>
+);
+
+const ErrorIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="h-7 w-7"
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="10" />
+    <line x1="12" y1="8" x2="12" y2="12" />
+    <line x1="12" y1="16" x2="12.01" y2="16" />
+  </svg>
+);
+
 export default function InsightsReportErrorState({
   error,
   variant = 'error',
+  onClose,
 }: InsightsReportErrorStateProps) {
-  const containerClassName =
-    variant === 'warning'
-      ? 'w-full max-w-xl rounded-2xl border border-amber-500/30 bg-amber-500/10 p-6 text-center text-amber-100 font-work-sans'
-      : 'w-full max-w-xl rounded-2xl border border-rose-500/20 bg-rose-500/10 p-6 text-center text-rose-200 font-work-sans';
+  const isWarning = variant === 'warning';
+
+  const title = isWarning ? 'Atenção' : 'Erro ao atualizar insights';
+
+  const accentColor = isWarning ? 'var(--neutral)' : 'var(--negative)';
+  const iconBg = isWarning
+    ? 'rgba(var(--neutral-rgb, 234 179 8) / 0.12)'
+    : 'rgba(var(--negative-rgb, 239 68 68) / 0.12)';
 
   return (
-    <div className="flex h-64 items-center justify-center">
-      <div className={containerClassName}>
-        {error}
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* Backdrop */}
+      <button
+        type="button"
+        aria-label="Fechar aviso"
+        onClick={onClose}
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+      />
+
+      {/* Dialog */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="relative w-full max-w-md overflow-hidden rounded-2xl border border-(--quaternary-color)/10 bg-gradient-to-br from-(--bg-secondary) to-(--sixth-color) shadow-2xl font-work-sans"
+      >
+        {/* Barra de cor superior */}
+        <div
+          className="h-1 w-full"
+          style={{ background: accentColor }}
+          aria-hidden="true"
+        />
+
+        <div className="flex flex-col items-center gap-4 px-8 py-8 text-center">
+          {/* Ícone */}
+          <div
+            className="flex items-center justify-center rounded-full p-3"
+            style={{ background: iconBg, color: accentColor }}
+          >
+            {isWarning ? <WarningIcon /> : <ErrorIcon />}
+          </div>
+
+          {/* Título */}
+          <h3
+            className="text-xl font-semibold font-montserrat"
+            style={{ color: accentColor }}
+          >
+            {title}
+          </h3>
+
+          {/* Mensagem */}
+          <p className="text-sm leading-relaxed text-(--text-secondary) max-w-xs">
+            {error}
+          </p>
+
+          {/* Divisor */}
+          <div className="w-full border-t border-(--quaternary-color)/10 pt-2" />
+
+          {/* Ação */}
+          <button
+            type="button"
+            onClick={onClose}
+            className="btn-primary font-poppins px-8 py-2.5 text-sm"
+          >
+            Entendido
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/components/user/pages/feedbacksInsightsReport/InsightsReportErrorState.tsx
+++ b/components/user/pages/feedbacksInsightsReport/InsightsReportErrorState.tsx
@@ -2,10 +2,16 @@ import type { InsightsReportErrorStateProps } from './ui.types';
 
 export default function InsightsReportErrorState({
   error,
+  variant = 'error',
 }: InsightsReportErrorStateProps) {
+  const containerClassName =
+    variant === 'warning'
+      ? 'w-full max-w-xl rounded-2xl border border-amber-500/30 bg-amber-500/10 p-6 text-center text-amber-100 font-work-sans'
+      : 'w-full max-w-xl rounded-2xl border border-rose-500/20 bg-rose-500/10 p-6 text-center text-rose-200 font-work-sans';
+
   return (
     <div className="flex h-64 items-center justify-center">
-      <div className="w-full max-w-xl rounded-2xl border border-rose-500/20 bg-rose-500/10 p-6 text-center text-rose-200 font-work-sans">
+      <div className={containerClassName}>
         {error}
       </div>
     </div>

--- a/components/user/pages/feedbacksInsightsReport/InsightsReportHeaderSection.tsx
+++ b/components/user/pages/feedbacksInsightsReport/InsightsReportHeaderSection.tsx
@@ -1,8 +1,11 @@
+import { Link } from 'react-router-dom';
 import type { InsightsReportHeaderSectionProps } from './ui.types';
 
 export default function InsightsReportHeaderSection({
   updatedLabel,
   refreshing,
+  canAnalyze,
+  analysisBlockedMessage,
   availableScopes,
   selectedScope,
   selectedCatalogItemId,
@@ -30,6 +33,8 @@ export default function InsightsReportHeaderSection({
   const missingRequiredItem =
     itemSelectionEnabled &&
     (selectedCatalogItemId.trim().length === 0 || filteredCatalogItems.length === 0);
+
+  const analysisDisabled = refreshing || missingRequiredItem || !canAnalyze;
 
   const buttonLabel =
     selectedScope === 'COMPANY' ? 'Atualizar' : 'Analisar item selecionado';
@@ -99,11 +104,25 @@ export default function InsightsReportHeaderSection({
         <button
           type="button"
           onClick={onRefreshSelected}
-          disabled={refreshing || missingRequiredItem}
+          disabled={analysisDisabled}
           className="btn-primary font-poppins px-4 py-2 text-sm disabled:opacity-60"
         >
           {refreshing ? 'Atualizando...' : buttonLabel}
         </button>
+
+        {!canAnalyze && analysisBlockedMessage && (
+          <p className="max-w-[280px] text-right text-xs text-(--text-tertiary)">
+            {analysisBlockedMessage}
+            {' '}
+            <Link
+              to="/user/edit/collecting-data-enterprise"
+              className="font-semibold text-(--text-primary) underline underline-offset-2"
+            >
+              Configurar agora
+            </Link>
+            .
+          </p>
+        )}
       </div>
     </div>
   );

--- a/components/user/pages/feedbacksInsightsReport/InsightsReportHeaderSection.tsx
+++ b/components/user/pages/feedbacksInsightsReport/InsightsReportHeaderSection.tsx
@@ -3,6 +3,7 @@ import type { InsightsReportHeaderSectionProps } from './ui.types';
 export default function InsightsReportHeaderSection({
   updatedLabel,
   refreshing,
+  availableScopes,
   selectedScope,
   selectedCatalogItemId,
   catalogItemOptions,
@@ -10,6 +11,16 @@ export default function InsightsReportHeaderSection({
   onCatalogItemChange,
   onRefreshSelected,
 }: InsightsReportHeaderSectionProps) {
+  const scopeLabels: Record<
+    'COMPANY' | 'PRODUCT' | 'SERVICE' | 'DEPARTMENT',
+    string
+  > = {
+    COMPANY: 'Empresa (visão geral)',
+    PRODUCT: 'Produto',
+    SERVICE: 'Serviço',
+    DEPARTMENT: 'Departamento',
+  };
+
   const itemSelectionEnabled = selectedScope !== 'COMPANY';
 
   const filteredCatalogItems = catalogItemOptions.filter(
@@ -50,10 +61,11 @@ export default function InsightsReportHeaderSection({
             }
             className="min-w-[220px] rounded-lg border border-(--quaternary-color)/20 bg-(--bg-primary) px-3 py-2 text-sm text-(--text-primary)"
           >
-            <option value="COMPANY">Empresa (visão geral)</option>
-            <option value="PRODUCT">Produto</option>
-            <option value="SERVICE">Serviço</option>
-            <option value="DEPARTMENT">Departamento</option>
+            {availableScopes.map((scope) => (
+              <option key={scope} value={scope}>
+                {scopeLabels[scope]}
+              </option>
+            ))}
           </select>
 
           {itemSelectionEnabled && (

--- a/components/user/pages/feedbacksInsightsReport/InsightsReportHeaderSection.tsx
+++ b/components/user/pages/feedbacksInsightsReport/InsightsReportHeaderSection.tsx
@@ -3,8 +3,20 @@ import type { InsightsReportHeaderSectionProps } from './ui.types';
 export default function InsightsReportHeaderSection({
   updatedLabel,
   refreshing,
-  onRefresh,
+  selectedScope,
+  selectedCatalogItemId,
+  catalogItemOptions,
+  onScopeChange,
+  onCatalogItemChange,
+  onRefreshSelected,
+  onRefreshAll,
 }: InsightsReportHeaderSectionProps) {
+  const itemSelectionEnabled = selectedScope !== 'COMPANY';
+
+  const filteredCatalogItems = catalogItemOptions.filter(
+    (item) => item.kind === selectedScope,
+  );
+
   return (
     <div className="font-work-sans mb-4 flex flex-col md:flex-row items-start justify-between gap-4">
       <div>
@@ -18,18 +30,66 @@ export default function InsightsReportHeaderSection({
         </p>
       </div>
       <div className="flex flex-col items-end gap-2">
+        <div className="flex w-full flex-col gap-2 md:w-auto md:items-end">
+          <select
+            value={selectedScope}
+            onChange={(event) =>
+              onScopeChange(
+                event.target.value as
+                  | 'COMPANY'
+                  | 'PRODUCT'
+                  | 'SERVICE'
+                  | 'DEPARTMENT',
+              )
+            }
+            className="min-w-[220px] rounded-lg border border-(--quaternary-color)/20 bg-(--bg-primary) px-3 py-2 text-sm text-(--text-primary)"
+          >
+            <option value="COMPANY">Empresa (visão geral)</option>
+            <option value="PRODUCT">Produto</option>
+            <option value="SERVICE">Serviço</option>
+            <option value="DEPARTMENT">Departamento</option>
+          </select>
+
+          {itemSelectionEnabled && (
+            <select
+              value={selectedCatalogItemId}
+              onChange={(event) => onCatalogItemChange(event.target.value)}
+              className="min-w-[220px] rounded-lg border border-(--quaternary-color)/20 bg-(--bg-primary) px-3 py-2 text-sm text-(--text-primary)"
+            >
+              <option value="">Todos os itens do escopo</option>
+              {filteredCatalogItems.map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.name}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+
         {updatedLabel && (
           <span className="text-[10px] uppercase tracking-wide text-[var(--text-tertiary)]">
             Última atualização: {updatedLabel}
           </span>
         )}
-        <button
-          type="button"
-          onClick={onRefresh}
-          disabled={refreshing}
-          className="btn-primary font-poppins px-4 py-2 text-sm disabled:opacity-60">
-          {refreshing ? 'Atualizando...' : 'Atualizar insights com IA'}
-        </button>
+
+        <div className="flex flex-wrap justify-end gap-2">
+          <button
+            type="button"
+            onClick={onRefreshSelected}
+            disabled={refreshing}
+            className="btn-primary font-poppins px-4 py-2 text-sm disabled:opacity-60"
+          >
+            {refreshing ? 'Atualizando...' : 'Atualizar escopo selecionado'}
+          </button>
+          <button
+            type="button"
+            onClick={onRefreshAll}
+            disabled={refreshing}
+            className="rounded-lg border border-(--quaternary-color)/30 px-4 py-2 text-sm text-(--text-primary) hover:bg-(--quaternary-color)/10 disabled:opacity-60"
+          >
+            Atualizar análise completa
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/components/user/pages/feedbacksInsightsReport/InsightsReportHeaderSection.tsx
+++ b/components/user/pages/feedbacksInsightsReport/InsightsReportHeaderSection.tsx
@@ -9,13 +9,19 @@ export default function InsightsReportHeaderSection({
   onScopeChange,
   onCatalogItemChange,
   onRefreshSelected,
-  onRefreshAll,
 }: InsightsReportHeaderSectionProps) {
   const itemSelectionEnabled = selectedScope !== 'COMPANY';
 
   const filteredCatalogItems = catalogItemOptions.filter(
     (item) => item.kind === selectedScope,
   );
+
+  const missingRequiredItem =
+    itemSelectionEnabled &&
+    (selectedCatalogItemId.trim().length === 0 || filteredCatalogItems.length === 0);
+
+  const buttonLabel =
+    selectedScope === 'COMPANY' ? 'Atualizar' : 'Analisar item selecionado';
 
   return (
     <div className="font-work-sans mb-4 flex flex-col md:flex-row items-start justify-between gap-4">
@@ -56,13 +62,19 @@ export default function InsightsReportHeaderSection({
               onChange={(event) => onCatalogItemChange(event.target.value)}
               className="min-w-[220px] rounded-lg border border-(--quaternary-color)/20 bg-(--bg-primary) px-3 py-2 text-sm text-(--text-primary)"
             >
-              <option value="">Todos os itens do escopo</option>
+              <option value="">Selecione um item</option>
               {filteredCatalogItems.map((item) => (
                 <option key={item.id} value={item.id}>
                   {item.name}
                 </option>
               ))}
             </select>
+          )}
+
+          {itemSelectionEnabled && filteredCatalogItems.length === 0 && (
+            <p className="text-xs text-(--text-tertiary)">
+              Nenhum item disponível neste escopo. Cadastre itens para analisar.
+            </p>
           )}
         </div>
 
@@ -72,24 +84,14 @@ export default function InsightsReportHeaderSection({
           </span>
         )}
 
-        <div className="flex flex-wrap justify-end gap-2">
-          <button
-            type="button"
-            onClick={onRefreshSelected}
-            disabled={refreshing}
-            className="btn-primary font-poppins px-4 py-2 text-sm disabled:opacity-60"
-          >
-            {refreshing ? 'Atualizando...' : 'Atualizar escopo selecionado'}
-          </button>
-          <button
-            type="button"
-            onClick={onRefreshAll}
-            disabled={refreshing}
-            className="rounded-lg border border-(--quaternary-color)/30 px-4 py-2 text-sm text-(--text-primary) hover:bg-(--quaternary-color)/10 disabled:opacity-60"
-          >
-            Atualizar análise completa
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={onRefreshSelected}
+          disabled={refreshing || missingRequiredItem}
+          className="btn-primary font-poppins px-4 py-2 text-sm disabled:opacity-60"
+        >
+          {refreshing ? 'Atualizando...' : buttonLabel}
+        </button>
       </div>
     </div>
   );

--- a/components/user/pages/feedbacksInsightsReport/ui.types.ts
+++ b/components/user/pages/feedbacksInsightsReport/ui.types.ts
@@ -15,6 +15,8 @@ export type InsightsCatalogItemOption = {
 export interface InsightsReportHeaderSectionProps {
   updatedLabel: string | null;
   refreshing: boolean;
+  canAnalyze: boolean;
+  analysisBlockedMessage: string | null;
   availableScopes: InsightScopeOption[];
   selectedScope: InsightScopeOption;
   selectedCatalogItemId: string;

--- a/components/user/pages/feedbacksInsightsReport/ui.types.ts
+++ b/components/user/pages/feedbacksInsightsReport/ui.types.ts
@@ -74,6 +74,7 @@ export interface InsightsReportRecommendationsSectionProps {
  */
 export interface InsightsReportErrorStateProps {
   error: string;
+  variant?: 'error' | 'warning';
 }
 
 /**

--- a/components/user/pages/feedbacksInsightsReport/ui.types.ts
+++ b/components/user/pages/feedbacksInsightsReport/ui.types.ts
@@ -15,6 +15,7 @@ export type InsightsCatalogItemOption = {
 export interface InsightsReportHeaderSectionProps {
   updatedLabel: string | null;
   refreshing: boolean;
+  availableScopes: InsightScopeOption[];
   selectedScope: InsightScopeOption;
   selectedCatalogItemId: string;
   catalogItemOptions: InsightsCatalogItemOption[];

--- a/components/user/pages/feedbacksInsightsReport/ui.types.ts
+++ b/components/user/pages/feedbacksInsightsReport/ui.types.ts
@@ -1,5 +1,13 @@
 import type { FeedbackAnalysisSummary } from 'lib/interfaces/domain/feedback.domain';
 
+export type InsightScopeOption = 'COMPANY' | 'PRODUCT' | 'SERVICE' | 'DEPARTMENT';
+
+export type InsightsCatalogItemOption = {
+  id: string;
+  name: string;
+  kind: Exclude<InsightScopeOption, 'COMPANY'>;
+};
+
 /**
  * Props do cabeçalho da tela de insights em relatório.
  * Usado em: components/user/pages/feedbacksInsightsReport/InsightsReportHeaderSection.tsx.
@@ -7,7 +15,13 @@ import type { FeedbackAnalysisSummary } from 'lib/interfaces/domain/feedback.dom
 export interface InsightsReportHeaderSectionProps {
   updatedLabel: string | null;
   refreshing: boolean;
-  onRefresh: () => void;
+  selectedScope: InsightScopeOption;
+  selectedCatalogItemId: string;
+  catalogItemOptions: InsightsCatalogItemOption[];
+  onScopeChange: (scope: InsightScopeOption) => void;
+  onCatalogItemChange: (catalogItemId: string) => void;
+  onRefreshSelected: () => void;
+  onRefreshAll: () => void;
 }
 
 /**

--- a/components/user/pages/feedbacksInsightsReport/ui.types.ts
+++ b/components/user/pages/feedbacksInsightsReport/ui.types.ts
@@ -21,7 +21,6 @@ export interface InsightsReportHeaderSectionProps {
   onScopeChange: (scope: InsightScopeOption) => void;
   onCatalogItemChange: (catalogItemId: string) => void;
   onRefreshSelected: () => void;
-  onRefreshAll: () => void;
 }
 
 /**

--- a/components/user/pages/feedbacksInsightsReport/ui.types.ts
+++ b/components/user/pages/feedbacksInsightsReport/ui.types.ts
@@ -75,6 +75,7 @@ export interface InsightsReportRecommendationsSectionProps {
 export interface InsightsReportErrorStateProps {
   error: string;
   variant?: 'error' | 'warning';
+  onClose: () => void;
 }
 
 /**

--- a/components/user/pages/profile/editCollectingData/fields/fieldCompanyFeedbackQuestions.tsx
+++ b/components/user/pages/profile/editCollectingData/fields/fieldCompanyFeedbackQuestions.tsx
@@ -1,0 +1,79 @@
+import { memo } from 'react';
+import type { FieldCompanyFeedbackQuestionsProps } from './ui.types';
+
+const TOTAL_COMPANY_QUESTIONS = 3;
+
+const FieldCompanyFeedbackQuestions = memo(function FieldCompanyFeedbackQuestions({
+  questions,
+  onChange,
+}: FieldCompanyFeedbackQuestionsProps) {
+  const ensureQuestion = (index: number) => {
+    return (
+      questions[index] ?? {
+        question_order: (index + 1) as 1 | 2 | 3,
+        question_text: '',
+        is_active: true,
+      }
+    );
+  };
+
+  return (
+    <div className="font-work-sans rounded-xl border border-(--quaternary-color)/10 bg-linear-to-br from-(--bg-secondary) to-(--sixth-color) p-5">
+      <div className="mb-4">
+        <h3 className="text-sm font-semibold text-(--text-primary)">
+          Perguntas Padrão de Feedback (Empresa)
+        </h3>
+        <p className="mt-1 text-xs text-(--text-tertiary)">
+          Edite os 3 campos que aparecerão no feedback geral via QR Code.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {Array.from({ length: TOTAL_COMPANY_QUESTIONS }).map((_, index) => {
+          const question = ensureQuestion(index);
+
+          return (
+            <div
+              key={`company-feedback-question-${index}`}
+              className="rounded-lg border border-(--quaternary-color)/10 bg-(--seventh-color) p-3"
+            >
+              <label className="mb-2 block text-xs text-(--text-secondary)">
+                Pergunta {index + 1}
+              </label>
+              <input
+                type="text"
+                value={question.question_text}
+                onChange={(event) => {
+                  const nextValue = event.target.value;
+
+                  onChange((prev) => {
+                    const next = [...prev];
+                    const current =
+                      next[index] ?? {
+                        question_order: (index + 1) as 1 | 2 | 3,
+                        question_text: '',
+                        is_active: true,
+                      };
+
+                    next[index] = {
+                      ...current,
+                      question_order: (index + 1) as 1 | 2 | 3,
+                      question_text: nextValue,
+                      is_active: true,
+                    };
+
+                    return next;
+                  });
+                }}
+                className="w-full rounded-lg border border-(--quaternary-color)/14 bg-(--bg-secondary) px-3 py-2 text-sm text-(--text-primary) outline-none transition-all placeholder:text-(--text-tertiary) focus:border-(--primary-color)"
+                placeholder={`Ex.: Pergunta ${index + 1}`}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+});
+
+export default FieldCompanyFeedbackQuestions;

--- a/components/user/pages/profile/editCollectingData/fields/ui.types.ts
+++ b/components/user/pages/profile/editCollectingData/fields/ui.types.ts
@@ -1,5 +1,8 @@
 import type { ChangeEvent, Dispatch, SetStateAction } from 'react';
-import type { CatalogItemInput } from 'lib/interfaces/entities/enterprise.entity';
+import type {
+  CatalogItemInput,
+  CompanyFeedbackQuestionInput,
+} from 'lib/interfaces/entities/enterprise.entity';
 
 /**
  * Props do campo de principais produtos/serviços.
@@ -46,6 +49,15 @@ export interface FieldUsesCompanyProductsProps {
   usesCompanyServices: boolean;
   usesCompanyDepartments: boolean;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+}
+
+/**
+ * Props do bloco de perguntas padrão de feedback da empresa.
+ * Usado em: components/user/pages/profile/editCollectingData/fields/fieldCompanyFeedbackQuestions.tsx.
+ */
+export interface FieldCompanyFeedbackQuestionsProps {
+  questions: CompanyFeedbackQuestionInput[];
+  onChange: Dispatch<SetStateAction<CompanyFeedbackQuestionInput[]>>;
 }
 
 /**

--- a/components/user/pages/profile/editCollectingData/formCollectingDataEnterprise.tsx
+++ b/components/user/pages/profile/editCollectingData/formCollectingDataEnterprise.tsx
@@ -194,7 +194,7 @@ export default function FormCollectingDataEnterprise() {
         companyFeedbackQuestions.map((question, index) => ({
           question_order: (index + 1) as 1 | 2 | 3,
           question_text: String(question.question_text ?? '').trim(),
-          is_active: true,
+          is_active: question.is_active ?? true,
         })),
       );
     }

--- a/components/user/pages/profile/editCollectingData/formCollectingDataEnterprise.tsx
+++ b/components/user/pages/profile/editCollectingData/formCollectingDataEnterprise.tsx
@@ -1,5 +1,6 @@
 import type {
   CatalogItemInput,
+  CompanyFeedbackQuestionInput,
   CollectingDataEnterprise,
 } from 'lib/interfaces/entities/enterprise.entity';
 import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
@@ -9,6 +10,26 @@ import FieldAnalyticsGoal from './fields/fieldAnalyticsGoal';
 import FieldBusinessSummary from './fields/fieldBusinessSummary';
 import FieldUsesCompanyProducts from './fields/fieldUsesCompanyProducts';
 import FieldCatalogItems from './fields/fieldCatalogItems';
+import FieldCompanyFeedbackQuestions from './fields/fieldCompanyFeedbackQuestions';
+
+const DEFAULT_COMPANY_FEEDBACK_QUESTIONS: CompanyFeedbackQuestionInput[] = [
+  {
+    question_order: 1,
+    question_text: 'Como foi sua experiência em relação ao atendimento?',
+    is_active: true,
+  },
+  {
+    question_order: 2,
+    question_text: 'O que você achou da qualidade do produto/serviço?',
+    is_active: true,
+  },
+  {
+    question_order: 3,
+    question_text:
+      'Como você avalia a relação entre o valor pago e a qualidade do produto/serviço?',
+    is_active: true,
+  },
+];
 
 function normalizeCatalogInput(items: CatalogItemInput[] | undefined) {
   return (items ?? []).map((item, index) => ({
@@ -28,6 +49,33 @@ function buildLegacyProducts(items: CatalogItemInput[]) {
     .map((item) => String(item.name ?? '').trim())
     .filter((name) => name.length > 0)
     .join('\n');
+}
+
+function normalizeCompanyFeedbackQuestions(
+  items: CollectingDataEnterprise['company_feedback_questions'] | undefined,
+) {
+  const byOrder = new Map<number, CompanyFeedbackQuestionInput>();
+
+  (items ?? []).forEach((item) => {
+    const order = Number(item.question_order);
+    if (!Number.isInteger(order) || order < 1 || order > 3) return;
+
+    byOrder.set(order, {
+      question_order: order as 1 | 2 | 3,
+      question_text: item.question_text ?? '',
+      is_active: item.is_active ?? true,
+    });
+  });
+
+  return DEFAULT_COMPANY_FEEDBACK_QUESTIONS.map((fallback, index) => {
+    const current = byOrder.get(index + 1);
+
+    return {
+      question_order: ((index + 1) as 1 | 2 | 3),
+      question_text: current?.question_text ?? fallback.question_text,
+      is_active: current?.is_active ?? true,
+    };
+  });
 }
 
 export default function FormCollectingDataEnterprise() {
@@ -58,6 +106,11 @@ export default function FormCollectingDataEnterprise() {
     [collecting?.catalog_departments],
   );
 
+  const initialCompanyFeedbackQuestions = useMemo(
+    () => normalizeCompanyFeedbackQuestions(collecting?.company_feedback_questions),
+    [collecting?.company_feedback_questions],
+  );
+
   const [usesCompanyProducts, setUsesCompanyProducts] = useState(
     collecting?.uses_company_products ?? false,
   );
@@ -70,10 +123,14 @@ export default function FormCollectingDataEnterprise() {
   const [productItems, setProductItems] = useState<CatalogItemInput[]>(() => initialProducts);
   const [serviceItems, setServiceItems] = useState<CatalogItemInput[]>(() => initialServices);
   const [departmentItems, setDepartmentItems] = useState<CatalogItemInput[]>(() => initialDepartments);
+  const [companyFeedbackQuestions, setCompanyFeedbackQuestions] = useState<CompanyFeedbackQuestionInput[]>(
+    () => initialCompanyFeedbackQuestions,
+  );
   const productsInputRef = useRef<HTMLInputElement | null>(null);
   const servicesInputRef = useRef<HTMLInputElement | null>(null);
   const departmentsInputRef = useRef<HTMLInputElement | null>(null);
   const legacyProductsInputRef = useRef<HTMLInputElement | null>(null);
+  const companyQuestionsInputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     if (!usesCompanyProducts) {
@@ -131,7 +188,17 @@ export default function FormCollectingDataEnterprise() {
     if (legacyProductsInputRef.current) {
       legacyProductsInputRef.current.value = buildLegacyProducts(productItems);
     }
-  }, [productItems, serviceItems, departmentItems]);
+
+    if (companyQuestionsInputRef.current) {
+      companyQuestionsInputRef.current.value = JSON.stringify(
+        companyFeedbackQuestions.map((question, index) => ({
+          question_order: (index + 1) as 1 | 2 | 3,
+          question_text: String(question.question_text ?? '').trim(),
+          is_active: true,
+        })),
+      );
+    }
+  }, [productItems, serviceItems, departmentItems, companyFeedbackQuestions]);
 
   return (
     <Form
@@ -181,6 +248,17 @@ export default function FormCollectingDataEnterprise() {
           type="hidden"
           name="main_products_or_services"
           defaultValue=""
+        />
+        <input
+          ref={companyQuestionsInputRef}
+          type="hidden"
+          name="company_feedback_questions"
+          defaultValue="[]"
+        />
+
+        <FieldCompanyFeedbackQuestions
+          questions={companyFeedbackQuestions}
+          onChange={setCompanyFeedbackQuestions}
         />
 
         {usesCompanyProducts && (

--- a/database/sql/DESCRICOES.md
+++ b/database/sql/DESCRICOES.md
@@ -9,6 +9,8 @@
 - `public.customer`: cadastro de clientes finais associados à empresa.
 - `public.tracked_devices`: rastreio de dispositivos por fingerprint, bloqueio e contagem de feedbacks.
 - `public.feedback`: feedback bruto enviado pelo cliente (mensagem, nota, vínculo com ponto/dispositivo/empresa).
+- `public.questions_of_feedbacks`: perguntas configuráveis por contexto de feedback (empresa/produto/serviço/departamento).
+- `public.feedback_question_answers`: respostas das perguntas dinâmicas vinculadas a cada feedback enviado.
 - `public.feedback_analysis`: resultado analítico do feedback (sentimento, categorias e palavras-chave).
 - `public.feedback_insights_report`: relatório consolidado de insights e recomendações por empresa.
 

--- a/database/sql/functions/public/create_enterprise_on_signup__cd0cc999bf.sql
+++ b/database/sql/functions/public/create_enterprise_on_signup__cd0cc999bf.sql
@@ -14,6 +14,7 @@ DECLARE
   v_terms_version      text        := NULLIF(meta->>'terms_version', '');
   v_terms_accepted_at  timestamptz := NULLIF(meta->>'terms_accepted_at', '')::timestamptz;
   v_phone              text        := NULLIF(meta->>'phone', '');
+  v_enterprise_id      uuid;
   v_exists int;
 BEGIN
   -- documento obrigatório
@@ -35,6 +36,44 @@ BEGIN
   INSERT INTO public.enterprise (document, account_type, terms_version, terms_accepted_at, auth_user_id)
   VALUES (v_document, v_account_type, v_terms_version, v_terms_accepted_at, NEW.id)
   ON CONFLICT (auth_user_id) DO NOTHING;
+
+  -- Busca a enterprise atual para semear perguntas padrão no contexto COMPANY.
+  SELECT e.id INTO v_enterprise_id
+  FROM public.enterprise e
+  WHERE e.auth_user_id = NEW.id
+  LIMIT 1;
+
+  IF v_enterprise_id IS NOT NULL AND to_regclass('public.questions_of_feedbacks') IS NOT NULL THEN
+    INSERT INTO public.questions_of_feedbacks (
+      enterprise_id,
+      scope_type,
+      catalog_item_id,
+      question_order,
+      question_text,
+      is_active
+    )
+    SELECT
+      v_enterprise_id,
+      'COMPANY',
+      NULL,
+      q.question_order,
+      q.question_text,
+      true
+    FROM (
+      VALUES
+        (1, 'Como foi sua experiência em relação ao atendimento?'),
+        (2, 'O que você achou da qualidade do produto/serviço?'),
+        (3, 'Como você avalia a relação entre o valor pago e a qualidade do produto/serviço?')
+    ) AS q(question_order, question_text)
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.questions_of_feedbacks existing
+      WHERE existing.enterprise_id = v_enterprise_id
+        AND existing.scope_type = 'COMPANY'
+        AND existing.catalog_item_id IS NULL
+        AND existing.question_order = q.question_order
+    );
+  END IF;
 
   -- valida duplicidade de telefone antes de atualizar auth.users
   IF v_phone IS NOT NULL THEN

--- a/database/sql/policies/all_policies.sql
+++ b/database/sql/policies/all_policies.sql
@@ -80,6 +80,52 @@ CREATE POLICY "Usuários autenticados podem gerenciar feedbacks" ON "public"."fe
   TO authenticated
   USING ((enterprise_id IN ( SELECT enterprise.id FROM enterprise WHERE (enterprise.auth_user_id = auth.uid()))));
 
+DROP POLICY IF EXISTS "Auth gerencia perguntas de feedback" ON "public"."questions_of_feedbacks";
+CREATE POLICY "Auth gerencia perguntas de feedback" ON "public"."questions_of_feedbacks"
+  AS PERMISSIVE
+  FOR ALL
+  TO authenticated
+  USING ((enterprise_id IN (SELECT enterprise.id FROM enterprise WHERE (enterprise.auth_user_id = auth.uid()))))
+  WITH CHECK ((enterprise_id IN (SELECT enterprise.id FROM enterprise WHERE (enterprise.auth_user_id = auth.uid()))));
+
+DROP POLICY IF EXISTS "Anon pode ler perguntas ativas de feedback" ON "public"."questions_of_feedbacks";
+CREATE POLICY "Anon pode ler perguntas ativas de feedback" ON "public"."questions_of_feedbacks"
+  AS PERMISSIVE
+  FOR SELECT
+  TO anon
+  USING ((is_active = true));
+
+DROP POLICY IF EXISTS "Auth gerencia respostas de perguntas de feedback" ON "public"."feedback_question_answers";
+CREATE POLICY "Auth gerencia respostas de perguntas de feedback" ON "public"."feedback_question_answers"
+  AS PERMISSIVE
+  FOR ALL
+  TO authenticated
+  USING ((feedback_id IN (
+    SELECT f.id
+    FROM feedback f
+    WHERE f.enterprise_id IN (
+      SELECT enterprise.id
+      FROM enterprise
+      WHERE enterprise.auth_user_id = auth.uid()
+    )
+  )))
+  WITH CHECK ((feedback_id IN (
+    SELECT f.id
+    FROM feedback f
+    WHERE f.enterprise_id IN (
+      SELECT enterprise.id
+      FROM enterprise
+      WHERE enterprise.auth_user_id = auth.uid()
+    )
+  )));
+
+DROP POLICY IF EXISTS "Anon pode inserir respostas de perguntas" ON "public"."feedback_question_answers";
+CREATE POLICY "Anon pode inserir respostas de perguntas" ON "public"."feedback_question_answers"
+  AS PERMISSIVE
+  FOR INSERT
+  TO anon
+  WITH CHECK ((feedback_id IS NOT NULL) AND (question_id IS NOT NULL));
+
 DROP POLICY IF EXISTS "Empresas gerenciam apenas suas próprias análises" ON "public"."feedback_analysis";
 CREATE POLICY "Empresas gerenciam apenas suas próprias análises" ON "public"."feedback_analysis"
   AS PERMISSIVE

--- a/database/sql/tables/public.feedback_insights_report.sql
+++ b/database/sql/tables/public.feedback_insights_report.sql
@@ -5,14 +5,153 @@
 CREATE SCHEMA IF NOT EXISTS "public";
 
 CREATE TABLE IF NOT EXISTS "public"."feedback_insights_report" (
-  "enterprise_id" uuid NOT NULL,
-  "summary" text,
-  "recommendations" ARRAY,
   "id" uuid DEFAULT gen_random_uuid() NOT NULL,
+  "enterprise_id" uuid NOT NULL,
+  "scope_type" text NOT NULL DEFAULT 'COMPANY',
+  "catalog_item_id" uuid,
+  "catalog_item_name" text,
+  "summary" text,
+  "recommendations" text[],
   "created_at" timestamp with time zone DEFAULT now(),
   "updated_at" timestamp with time zone DEFAULT now(),
   PRIMARY KEY ("id")
 );
+
+ALTER TABLE "public"."feedback_insights_report"
+  ADD COLUMN IF NOT EXISTS "scope_type" text;
+
+ALTER TABLE "public"."feedback_insights_report"
+  ALTER COLUMN "scope_type" SET DEFAULT 'COMPANY';
+
+UPDATE "public"."feedback_insights_report"
+SET "scope_type" = 'COMPANY'
+WHERE "scope_type" IS NULL;
+
+ALTER TABLE "public"."feedback_insights_report"
+  ALTER COLUMN "scope_type" SET NOT NULL;
+
+ALTER TABLE "public"."feedback_insights_report"
+  ADD COLUMN IF NOT EXISTS "catalog_item_id" uuid;
+
+ALTER TABLE "public"."feedback_insights_report"
+  ADD COLUMN IF NOT EXISTS "catalog_item_name" text;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'feedback_insights_report'
+      AND column_name = 'recommendations'
+      AND udt_name <> '_text'
+  ) THEN
+    ALTER TABLE "public"."feedback_insights_report"
+      ALTER COLUMN "recommendations" TYPE text[] USING
+      CASE
+        WHEN "recommendations" IS NULL THEN NULL
+        ELSE "recommendations"::text[]
+      END;
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'feedback_insights_report_scope_type_check'
+  ) THEN
+    ALTER TABLE "public"."feedback_insights_report"
+      ADD CONSTRAINT "feedback_insights_report_scope_type_check"
+      CHECK (("scope_type" = ANY (ARRAY['COMPANY'::text, 'PRODUCT'::text, 'SERVICE'::text, 'DEPARTMENT'::text])));
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'feedback_insights_report_enterprise_id_fkey'
+  ) THEN
+    ALTER TABLE "public"."feedback_insights_report"
+      ADD CONSTRAINT "feedback_insights_report_enterprise_id_fkey"
+      FOREIGN KEY ("enterprise_id")
+      REFERENCES "public"."enterprise"("id")
+      ON DELETE CASCADE;
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'feedback_insights_report_catalog_item_id_fkey'
+  ) THEN
+    ALTER TABLE "public"."feedback_insights_report"
+      ADD CONSTRAINT "feedback_insights_report_catalog_item_id_fkey"
+      FOREIGN KEY ("catalog_item_id")
+      REFERENCES "public"."catalog_items"("id")
+      ON DELETE CASCADE;
+  END IF;
+END
+$$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_feedback_insights_context"
+  ON "public"."feedback_insights_report" ("enterprise_id", "scope_type", "catalog_item_id") NULLS NOT DISTINCT;
+
+CREATE INDEX IF NOT EXISTS "idx_feedback_insights_report_enterprise_updated"
+  ON "public"."feedback_insights_report" ("enterprise_id", "updated_at" DESC);
+
+CREATE OR REPLACE FUNCTION public.validate_feedback_insights_report_context()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+DECLARE
+  catalog_kind text;
+  catalog_enterprise_id uuid;
+BEGIN
+  IF NEW.scope_type = 'COMPANY' THEN
+    IF NEW.catalog_item_id IS NOT NULL THEN
+      RAISE EXCEPTION 'catalog_item_id must be null when scope_type is COMPANY';
+    END IF;
+  ELSE
+    IF NEW.catalog_item_id IS NULL THEN
+      RAISE EXCEPTION 'catalog_item_id is required for item scope insights report';
+    END IF;
+
+    SELECT ci.kind, ci.enterprise_id
+    INTO catalog_kind, catalog_enterprise_id
+    FROM public.catalog_items ci
+    WHERE ci.id = NEW.catalog_item_id;
+
+    IF catalog_kind IS NULL THEN
+      RAISE EXCEPTION 'catalog_item not found for feedback_insights_report';
+    END IF;
+
+    IF catalog_enterprise_id <> NEW.enterprise_id THEN
+      RAISE EXCEPTION 'catalog_item enterprise_id mismatch in feedback_insights_report';
+    END IF;
+
+    IF catalog_kind <> NEW.scope_type THEN
+      RAISE EXCEPTION 'scope_type must match catalog_item kind in feedback_insights_report';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS "validate_feedback_insights_report_context" ON "public"."feedback_insights_report";
+CREATE TRIGGER "validate_feedback_insights_report_context"
+  BEFORE INSERT OR UPDATE ON "public"."feedback_insights_report"
+  FOR EACH ROW
+  EXECUTE FUNCTION public.validate_feedback_insights_report_context();
 
 ALTER TABLE "public"."feedback_insights_report" ENABLE ROW LEVEL SECURITY;
 
@@ -38,4 +177,10 @@ CREATE POLICY "feedback_insights_report_update" ON "public"."feedback_insights_r
   TO public
   USING ((enterprise_id IN ( SELECT enterprise.id FROM enterprise WHERE (enterprise.auth_user_id = auth.uid()))))
   WITH CHECK ((enterprise_id IN ( SELECT enterprise.id FROM enterprise WHERE (enterprise.auth_user_id = auth.uid()))));
+
+-- Triggers
+DROP TRIGGER IF EXISTS "set_updated_at" ON "public"."feedback_insights_report";
+CREATE TRIGGER "set_updated_at" BEFORE UPDATE ON "public"."feedback_insights_report"
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
 

--- a/database/sql/tables/public.feedback_question_answers.sql
+++ b/database/sql/tables/public.feedback_question_answers.sql
@@ -1,0 +1,130 @@
+-- Descrição: Respostas das perguntas dinâmicas por feedback enviado.
+-- Uso: Armazena a resposta selecionada para cada pergunta de contexto no momento do envio.
+
+-- public.feedback_question_answers
+CREATE SCHEMA IF NOT EXISTS "public";
+
+CREATE TABLE IF NOT EXISTS "public"."feedback_question_answers" (
+  "id" uuid DEFAULT gen_random_uuid() NOT NULL,
+  "feedback_id" uuid NOT NULL,
+  "question_id" uuid NOT NULL,
+  "question_text_snapshot" text NOT NULL,
+  "answer_value" text NOT NULL,
+  "answer_score" integer NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  PRIMARY KEY ("id")
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'feedback_question_answers_answer_value_check'
+  ) THEN
+    ALTER TABLE "public"."feedback_question_answers"
+      ADD CONSTRAINT "feedback_question_answers_answer_value_check"
+      CHECK (("answer_value" = ANY (ARRAY['PESSIMO'::text, 'RUIM'::text, 'MEDIANA'::text, 'BOA'::text, 'OTIMA'::text])));
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'feedback_question_answers_answer_score_check'
+  ) THEN
+    ALTER TABLE "public"."feedback_question_answers"
+      ADD CONSTRAINT "feedback_question_answers_answer_score_check"
+      CHECK (("answer_score" >= 1 AND "answer_score" <= 5));
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'feedback_question_answers_feedback_id_fkey'
+  ) THEN
+    ALTER TABLE "public"."feedback_question_answers"
+      ADD CONSTRAINT "feedback_question_answers_feedback_id_fkey"
+      FOREIGN KEY ("feedback_id")
+      REFERENCES "public"."feedback"("id")
+      ON DELETE CASCADE;
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'feedback_question_answers_question_id_fkey'
+  ) THEN
+    ALTER TABLE "public"."feedback_question_answers"
+      ADD CONSTRAINT "feedback_question_answers_question_id_fkey"
+      FOREIGN KEY ("question_id")
+      REFERENCES "public"."questions_of_feedbacks"("id")
+      ON DELETE RESTRICT;
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'feedback_question_answers_feedback_question_unique'
+  ) THEN
+    ALTER TABLE "public"."feedback_question_answers"
+      ADD CONSTRAINT "feedback_question_answers_feedback_question_unique"
+      UNIQUE ("feedback_id", "question_id");
+  END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS "idx_feedback_question_answers_feedback_id"
+  ON "public"."feedback_question_answers" ("feedback_id");
+
+CREATE INDEX IF NOT EXISTS "idx_feedback_question_answers_question_id"
+  ON "public"."feedback_question_answers" ("question_id");
+
+ALTER TABLE "public"."feedback_question_answers" ENABLE ROW LEVEL SECURITY;
+
+-- Policies
+DROP POLICY IF EXISTS "Auth gerencia respostas de perguntas de feedback" ON "public"."feedback_question_answers";
+CREATE POLICY "Auth gerencia respostas de perguntas de feedback" ON "public"."feedback_question_answers"
+  AS PERMISSIVE
+  FOR ALL
+  TO authenticated
+  USING ((feedback_id IN (
+    SELECT f.id
+    FROM feedback f
+    WHERE f.enterprise_id IN (
+      SELECT enterprise.id
+      FROM enterprise
+      WHERE enterprise.auth_user_id = auth.uid()
+    )
+  )))
+  WITH CHECK ((feedback_id IN (
+    SELECT f.id
+    FROM feedback f
+    WHERE f.enterprise_id IN (
+      SELECT enterprise.id
+      FROM enterprise
+      WHERE enterprise.auth_user_id = auth.uid()
+    )
+  )));
+
+DROP POLICY IF EXISTS "Anon pode inserir respostas de perguntas" ON "public"."feedback_question_answers";
+CREATE POLICY "Anon pode inserir respostas de perguntas" ON "public"."feedback_question_answers"
+  AS PERMISSIVE
+  FOR INSERT
+  TO anon
+  WITH CHECK ((feedback_id IS NOT NULL) AND (question_id IS NOT NULL));

--- a/database/sql/tables/public.questions_of_feedbacks.sql
+++ b/database/sql/tables/public.questions_of_feedbacks.sql
@@ -1,0 +1,190 @@
+-- Descrição: Perguntas dinâmicas por contexto de feedback (empresa, produto, serviço, departamento).
+-- Uso: Define as 3 perguntas exibidas no formulário público e editadas no painel privado.
+
+-- public.questions_of_feedbacks
+CREATE SCHEMA IF NOT EXISTS "public";
+
+CREATE TABLE IF NOT EXISTS "public"."questions_of_feedbacks" (
+  "id" uuid DEFAULT gen_random_uuid() NOT NULL,
+  "enterprise_id" uuid NOT NULL,
+  "scope_type" text NOT NULL,
+  "catalog_item_id" uuid,
+  "question_order" integer NOT NULL,
+  "question_text" text NOT NULL,
+  "is_active" boolean DEFAULT true NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  PRIMARY KEY ("id")
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'questions_of_feedbacks_scope_type_check'
+  ) THEN
+    ALTER TABLE "public"."questions_of_feedbacks"
+      ADD CONSTRAINT "questions_of_feedbacks_scope_type_check"
+      CHECK (("scope_type" = ANY (ARRAY['COMPANY'::text, 'PRODUCT'::text, 'SERVICE'::text, 'DEPARTMENT'::text])));
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'questions_of_feedbacks_question_order_check'
+  ) THEN
+    ALTER TABLE "public"."questions_of_feedbacks"
+      ADD CONSTRAINT "questions_of_feedbacks_question_order_check"
+      CHECK (("question_order" >= 1 AND "question_order" <= 3));
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'questions_of_feedbacks_enterprise_id_fkey'
+  ) THEN
+    ALTER TABLE "public"."questions_of_feedbacks"
+      ADD CONSTRAINT "questions_of_feedbacks_enterprise_id_fkey"
+      FOREIGN KEY ("enterprise_id")
+      REFERENCES "public"."enterprise"("id")
+      ON DELETE CASCADE;
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'questions_of_feedbacks_catalog_item_id_fkey'
+  ) THEN
+    ALTER TABLE "public"."questions_of_feedbacks"
+      ADD CONSTRAINT "questions_of_feedbacks_catalog_item_id_fkey"
+      FOREIGN KEY ("catalog_item_id")
+      REFERENCES "public"."catalog_items"("id")
+      ON DELETE CASCADE;
+  END IF;
+END
+$$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_questions_company_order"
+  ON "public"."questions_of_feedbacks" ("enterprise_id", "question_order")
+  WHERE ("scope_type" = 'COMPANY'::text AND "catalog_item_id" IS NULL);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_questions_item_order"
+  ON "public"."questions_of_feedbacks" ("enterprise_id", "scope_type", "catalog_item_id", "question_order")
+  WHERE ("scope_type" IN ('PRODUCT'::text, 'SERVICE'::text, 'DEPARTMENT'::text) AND "catalog_item_id" IS NOT NULL);
+
+CREATE INDEX IF NOT EXISTS "idx_questions_context"
+  ON "public"."questions_of_feedbacks" ("enterprise_id", "scope_type", "catalog_item_id", "is_active");
+
+CREATE OR REPLACE FUNCTION public.validate_questions_of_feedbacks_context()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+DECLARE
+  catalog_kind text;
+  catalog_enterprise_id uuid;
+BEGIN
+  IF NEW.scope_type = 'COMPANY' THEN
+    IF NEW.catalog_item_id IS NOT NULL THEN
+      RAISE EXCEPTION 'catalog_item_id must be null when scope_type is COMPANY';
+    END IF;
+  ELSE
+    IF NEW.catalog_item_id IS NULL THEN
+      RAISE EXCEPTION 'catalog_item_id is required for item scope questions';
+    END IF;
+
+    SELECT ci.kind, ci.enterprise_id
+    INTO catalog_kind, catalog_enterprise_id
+    FROM public.catalog_items ci
+    WHERE ci.id = NEW.catalog_item_id;
+
+    IF catalog_kind IS NULL THEN
+      RAISE EXCEPTION 'catalog_item not found for questions_of_feedbacks';
+    END IF;
+
+    IF catalog_enterprise_id <> NEW.enterprise_id THEN
+      RAISE EXCEPTION 'catalog_item enterprise_id mismatch in questions_of_feedbacks';
+    END IF;
+
+    IF catalog_kind <> NEW.scope_type THEN
+      RAISE EXCEPTION 'scope_type must match catalog_item kind';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS "validate_questions_of_feedbacks_context" ON "public"."questions_of_feedbacks";
+CREATE TRIGGER "validate_questions_of_feedbacks_context"
+  BEFORE INSERT OR UPDATE ON "public"."questions_of_feedbacks"
+  FOR EACH ROW
+  EXECUTE FUNCTION public.validate_questions_of_feedbacks_context();
+
+ALTER TABLE "public"."questions_of_feedbacks" ENABLE ROW LEVEL SECURITY;
+
+-- Policies
+DROP POLICY IF EXISTS "Auth gerencia perguntas de feedback" ON "public"."questions_of_feedbacks";
+CREATE POLICY "Auth gerencia perguntas de feedback" ON "public"."questions_of_feedbacks"
+  AS PERMISSIVE
+  FOR ALL
+  TO authenticated
+  USING ((enterprise_id IN (SELECT enterprise.id FROM enterprise WHERE (enterprise.auth_user_id = auth.uid()))))
+  WITH CHECK ((enterprise_id IN (SELECT enterprise.id FROM enterprise WHERE (enterprise.auth_user_id = auth.uid()))));
+
+DROP POLICY IF EXISTS "Anon pode ler perguntas ativas de feedback" ON "public"."questions_of_feedbacks";
+CREATE POLICY "Anon pode ler perguntas ativas de feedback" ON "public"."questions_of_feedbacks"
+  AS PERMISSIVE
+  FOR SELECT
+  TO anon
+  USING ((is_active = true));
+
+-- Triggers
+DROP TRIGGER IF EXISTS "set_updated_at" ON "public"."questions_of_feedbacks";
+CREATE TRIGGER "set_updated_at" BEFORE UPDATE ON "public"."questions_of_feedbacks"
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+-- Backfill idempotente das 3 perguntas padrão para COMPANY em empresas existentes
+INSERT INTO "public"."questions_of_feedbacks" (
+  enterprise_id,
+  scope_type,
+  catalog_item_id,
+  question_order,
+  question_text,
+  is_active
+)
+SELECT
+  e.id,
+  'COMPANY',
+  NULL,
+  q.question_order,
+  q.question_text,
+  true
+FROM "public"."enterprise" e
+CROSS JOIN (
+  VALUES
+    (1, 'Como foi sua experiência em relação ao atendimento?'),
+    (2, 'O que você achou da qualidade do produto/serviço?'),
+    (3, 'Como você avalia a relação entre o valor pago e a qualidade do produto/serviço?')
+) AS q(question_order, question_text)
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "public"."questions_of_feedbacks" existing
+  WHERE existing.enterprise_id = e.id
+    AND existing.scope_type = 'COMPANY'
+    AND existing.catalog_item_id IS NULL
+    AND existing.question_order = q.question_order
+);

--- a/database/sql/triggers/all_triggers.sql
+++ b/database/sql/triggers/all_triggers.sql
@@ -41,6 +41,17 @@ CREATE TRIGGER "set_updated_at" BEFORE UPDATE ON "public"."feedback"
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
 
+DROP TRIGGER IF EXISTS "validate_questions_of_feedbacks_context" ON "public"."questions_of_feedbacks";
+CREATE TRIGGER "validate_questions_of_feedbacks_context"
+  BEFORE INSERT OR UPDATE ON "public"."questions_of_feedbacks"
+  FOR EACH ROW
+  EXECUTE FUNCTION public.validate_questions_of_feedbacks_context();
+
+DROP TRIGGER IF EXISTS "set_updated_at" ON "public"."questions_of_feedbacks";
+CREATE TRIGGER "set_updated_at" BEFORE UPDATE ON "public"."questions_of_feedbacks"
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
 DROP TRIGGER IF EXISTS "set_updated_at" ON "public"."feedback_analysis";
 CREATE TRIGGER "set_updated_at" BEFORE UPDATE ON "public"."feedback_analysis"
   FOR EACH ROW

--- a/lib/interfaces/contracts/enterprise.contract.ts
+++ b/lib/interfaces/contracts/enterprise.contract.ts
@@ -1,3 +1,5 @@
+import type { FeedbackQuestionPublic } from './qrcode.contract';
+
 /**
  * Resposta mínima de empresa usada na validação de QR Code.
  * Usado em: src/services/serviceEnterprise.ts.
@@ -9,6 +11,7 @@ export interface EnterpriseContractResponse {
   catalog_item_id?: string | null;
   item_name?: string | null;
   item_kind?: 'PRODUCT' | 'SERVICE' | 'DEPARTMENT' | null;
+  questions?: FeedbackQuestionPublic[];
 }
 
 /**

--- a/lib/interfaces/contracts/qrcode.contract.ts
+++ b/lib/interfaces/contracts/qrcode.contract.ts
@@ -16,6 +16,26 @@ export interface QrcodeFeedbackErrorResponse {
   details?: string;
 }
 
+export type FeedbackAnswerValue =
+  | 'PESSIMO'
+  | 'RUIM'
+  | 'MEDIANA'
+  | 'BOA'
+  | 'OTIMA';
+
+export interface FeedbackQuestionPublic {
+  id: string;
+  scope_type: 'COMPANY' | 'PRODUCT' | 'SERVICE' | 'DEPARTMENT';
+  catalog_item_id: string | null;
+  question_order: 1 | 2 | 3;
+  question_text: string;
+}
+
+export interface FeedbackQuestionAnswerInput {
+  question_id: string;
+  answer_value: FeedbackAnswerValue;
+}
+
 /**
  * Dados principais do feedback enviados pelo formulário público.
  * Usado em: pages/public/qrcode/enterprise.tsx e components/public/forms/fields/fieldsQRCode/ui.types.ts.
@@ -23,6 +43,7 @@ export interface QrcodeFeedbackErrorResponse {
 export interface FeedbackData {
   message: string;
   rating: number;
+  answers: FeedbackQuestionAnswerInput[];
   enterprise_id: string;
   collection_point_id?: string;
   catalog_item_id?: string;

--- a/lib/interfaces/domain/feedback.domain.ts
+++ b/lib/interfaces/domain/feedback.domain.ts
@@ -146,6 +146,8 @@ export type FeedbackCategory =
   | 'SERVICE'
   | 'DEPARTMENT';
 
+export type FeedbackInsightScopeType = FeedbackCategory;
+
 /**
  * Sentimento classificado para um feedback analisado.
  * Usado em: lib/interfaces/domain/feedback.domain.ts (composição de FeedbackAnalysisItem).
@@ -195,6 +197,12 @@ export interface FeedbackAnalysisResponse {
   summary: FeedbackAnalysisSummary;
 }
 
+export type FeedbackAnalysisOptions = {
+  sentiment?: FeedbackSentiment;
+  scope_type?: FeedbackInsightScopeType;
+  catalog_item_id?: string;
+};
+
 /**
  * Relatório textual de insights e recomendações gerado para feedbacks.
  * Usado em: src/routes/load/loadFeedbackInsightsReport.ts e pages/user/feedbacks/insights/feedbackInsightsReport.tsx.
@@ -203,4 +211,11 @@ export interface FeedbackInsightsReport {
   summary: string | null;
   recommendations: string[];
   updatedAt: string | null;
+  scopeType?: FeedbackInsightScopeType;
+  catalogItemId?: string | null;
 }
+
+export type FeedbackInsightsReportOptions = {
+  scope_type?: FeedbackInsightScopeType;
+  catalog_item_id?: string;
+};

--- a/lib/interfaces/domain/feedback.domain.ts
+++ b/lib/interfaces/domain/feedback.domain.ts
@@ -43,6 +43,17 @@ export interface CollectionPoint {
 }
 
 /**
+ * Resposta de uma pergunta dinâmica vinculada ao feedback.
+ * Usado em: componentes de listagem/detalhe de feedback e dashboard.
+ */
+export interface FeedbackQuestionAnswer {
+  question_id: string;
+  question_text_snapshot: string;
+  answer_value: 'PESSIMO' | 'RUIM' | 'MEDIANA' | 'BOA' | 'OTIMA';
+  answer_score: number;
+}
+
+/**
  * Entidade de feedback com vínculo de canal e dispositivo rastreado.
  * Usado em: src/services/serviceFeedbacks.ts, src/routes/load/loadFeedbacks.ts, loaderUserDashboard.ts e components/user/pages/feedbacksAll/ui.types.ts.
  */
@@ -54,6 +65,7 @@ export interface Feedback {
   updated_at: string;
   collection_points: CollectionPoint;
   tracked_devices: TrackedDevice | null;
+  feedback_question_answers?: FeedbackQuestionAnswer[];
 }
 
 /**

--- a/lib/interfaces/entities/enterprise.entity.ts
+++ b/lib/interfaces/entities/enterprise.entity.ts
@@ -41,12 +41,31 @@ export interface CollectingDataEnterprise {
   uses_company_products: boolean;
   uses_company_services: boolean;
   uses_company_departments: boolean;
+  company_feedback_questions?: CompanyFeedbackQuestion[];
   catalog_products?: CatalogItem[];
   catalog_services?: CatalogItem[];
   catalog_departments?: CatalogItem[];
   created_at: string;
   updated_at: string;
 }
+
+export interface CompanyFeedbackQuestion {
+  id: string;
+  enterprise_id: string;
+  scope_type: 'COMPANY';
+  catalog_item_id: null;
+  question_order: 1 | 2 | 3;
+  question_text: string;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export type CompanyFeedbackQuestionInput = {
+  question_order: 1 | 2 | 3;
+  question_text: string;
+  is_active?: boolean;
+};
 
 export type CatalogItemKind = 'PRODUCT' | 'SERVICE' | 'DEPARTMENT';
 
@@ -89,6 +108,7 @@ export type UpdateCollectingDataPayload = Partial<
   catalog_products?: CatalogItemInput[] | null;
   catalog_services?: CatalogItemInput[] | null;
   catalog_departments?: CatalogItemInput[] | null;
+  company_feedback_questions?: CompanyFeedbackQuestionInput[] | null;
 };
 
 /**

--- a/lib/schemas/public/feedbackSchema.ts
+++ b/lib/schemas/public/feedbackSchema.ts
@@ -5,6 +5,14 @@ export const feedbackBaseSchema = z.object({
   enterprise_id: z.uuidv4(),
   rating: z.number().int().min(1).max(5),
   message: z.string().min(3).max(5000),
+  answers: z
+    .array(
+      z.object({
+        question_id: z.uuidv4(),
+        answer_value: z.enum(['PESSIMO', 'RUIM', 'MEDIANA', 'BOA', 'OTIMA']),
+      }),
+    )
+    .length(3),
 
   // opcionais
   customer_name: z.string().min(1).max(120).optional(),

--- a/pages/public/qrcode/enterprise.tsx
+++ b/pages/public/qrcode/enterprise.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useFetcher, useLoaderData } from 'react-router-dom';
 import Card from 'components/public/shared/card';
 import SVGImageProfile from 'components/svg/imageProfile';
@@ -25,7 +25,10 @@ export default function FeedbackQRCodeEnterprise() {
   const enterpriseName = loaderData?.enterpriseName ?? '';
   const itemName = loaderData?.itemName ?? '';
   const itemKind = loaderData?.itemKind ?? null;
-  const questions = loaderData?.questions ?? [];
+  const questions = useMemo(
+    () => loaderData?.questions ?? [],
+    [loaderData?.questions],
+  );
 
   const itemKindLabel =
     itemKind === 'PRODUCT'

--- a/pages/public/qrcode/enterprise.tsx
+++ b/pages/public/qrcode/enterprise.tsx
@@ -2,7 +2,11 @@ import { useEffect, useState } from 'react';
 import { useFetcher, useLoaderData } from 'react-router-dom';
 import Card from 'components/public/shared/card';
 import SVGImageProfile from 'components/svg/imageProfile';
-import type { CustomerData, FeedbackData } from 'lib/interfaces/contracts/qrcode.contract';
+import type {
+  CustomerData,
+  FeedbackAnswerValue,
+  FeedbackData,
+} from 'lib/interfaces/contracts/qrcode.contract';
 import StateSentPreviousFeedback from 'components/public/qrcode/enterprise/stateSentPreviousFeedback';
 import StateError from 'components/public/qrcode/enterprise/stateError';
 import StateSubmitted from 'components/public/qrcode/enterprise/stateSubmitted';
@@ -21,6 +25,7 @@ export default function FeedbackQRCodeEnterprise() {
   const enterpriseName = loaderData?.enterpriseName ?? '';
   const itemName = loaderData?.itemName ?? '';
   const itemKind = loaderData?.itemKind ?? null;
+  const questions = loaderData?.questions ?? [];
 
   const itemKindLabel =
     itemKind === 'PRODUCT'
@@ -34,6 +39,7 @@ export default function FeedbackQRCodeEnterprise() {
   const [formData, setFormData] = useState<FeedbackData>({
     message: '',
     rating: 0,
+    answers: [],
     enterprise_id: enterpriseId,
     collection_point_id: collectionPointId || undefined,
     catalog_item_id: catalogItemId || undefined,
@@ -65,6 +71,15 @@ export default function FeedbackQRCodeEnterprise() {
     }
   }, [fetcher.state, fetcher.data]);
 
+  useEffect(() => {
+    const questionIds = new Set(questions.map((question) => question.id));
+
+    setFormData((prev) => ({
+      ...prev,
+      answers: prev.answers.filter((answer) => questionIds.has(answer.question_id)),
+    }));
+  }, [questions]);
+
   const handleFormDataChange = (data: Partial<FeedbackData>) => {
     setFormData((prev) => ({ ...prev, ...data }));
   };
@@ -74,6 +89,25 @@ export default function FeedbackQRCodeEnterprise() {
     value: string | undefined,
   ) => {
     setCustomerData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleAnswerChange = (
+    questionId: string,
+    answerValue: FeedbackAnswerValue,
+  ) => {
+    setFormData((prev) => {
+      const answersWithoutCurrentQuestion = prev.answers.filter(
+        (answer) => answer.question_id !== questionId,
+      );
+
+      return {
+        ...prev,
+        answers: [
+          ...answersWithoutCurrentQuestion,
+          { question_id: questionId, answer_value: answerValue },
+        ],
+      };
+    });
   };
 
   const handleToggleOptionalFields = () => {
@@ -98,7 +132,31 @@ export default function FeedbackQRCodeEnterprise() {
       return;
     }
 
+    if (questions.length !== 3) {
+      setError('Perguntas de feedback ainda não configuradas para este QR Code.');
+      return;
+    }
+
+    const questionIds = new Set(questions.map((question) => question.id));
+    const hasAllAnswers =
+      formData.answers.length === 3 &&
+      formData.answers.every((answer) => questionIds.has(answer.question_id));
+
+    if (!hasAllAnswers) {
+      setError('Responda as 3 perguntas antes de enviar.');
+      return;
+    }
+
     setError('');
+
+    const answersByQuestionId = new Map(
+      formData.answers.map((answer) => [answer.question_id, answer]),
+    );
+
+    const orderedAnswers = [...questions]
+      .sort((left, right) => left.question_order - right.question_order)
+      .map((question) => answersByQuestionId.get(question.id))
+      .filter((answer): answer is NonNullable<typeof answer> => Boolean(answer));
 
     fetcher.submit(
       {
@@ -107,6 +165,7 @@ export default function FeedbackQRCodeEnterprise() {
         catalog_item_id: formData.catalog_item_id ?? '',
         message: formData.message.trim(),
         rating: String(formData.rating),
+        answers: JSON.stringify(orderedAnswers),
         customer_name: customerData.customer_name ?? '',
         customer_email: customerData.customer_email ?? '',
         customer_gender: customerData.customer_gender ?? '',
@@ -146,11 +205,13 @@ export default function FeedbackQRCodeEnterprise() {
         children={
           <FormQRCodeFeedback
             formData={formData}
+            questions={questions}
             customerData={customerData}
             showOptionalFields={showOptionalFields}
             error={error}
             isSubmitting={isSubmitting}
             onFormDataChange={handleFormDataChange}
+            onAnswerChange={handleAnswerChange}
             onCustomerDataChange={handleCustomerDataChange}
             onToggleOptionalFields={handleToggleOptionalFields}
             onSubmit={handleSubmit}

--- a/pages/user/feedbacks/insights/feedbackInsightsReport.tsx
+++ b/pages/user/feedbacks/insights/feedbackInsightsReport.tsx
@@ -1,5 +1,10 @@
 import { useEffect } from 'react';
-import { useFetcher, useLoaderData, useRevalidator } from 'react-router-dom';
+import {
+  useFetcher,
+  useLoaderData,
+  useRevalidator,
+  useSearchParams,
+} from 'react-router-dom';
 import type {
   FeedbackAnalysisSummary,
 } from 'lib/interfaces/domain/feedback.domain';
@@ -13,6 +18,7 @@ import InsightsReportMoodSection from 'components/user/pages/feedbacksInsightsRe
 import InsightsReportSummarySection from 'components/user/pages/feedbacksInsightsReport/InsightsReportSummarySection';
 import InsightsReportRecommendationsSection from 'components/user/pages/feedbacksInsightsReport/InsightsReportRecommendationsSection';
 import type { FeedbackInsightsReportActionData } from './ui.types';
+import type { InsightScopeOption } from 'components/user/pages/feedbacksInsightsReport/ui.types';
 
 function getMoodFromSummary(summary: FeedbackAnalysisSummary | null) {
   if (!summary || summary.totalAnalyzed === 0) {
@@ -54,7 +60,14 @@ function getMoodFromSummary(summary: FeedbackAnalysisSummary | null) {
 }
 
 export default function FeedbacksInsightsReport() {
-  const { report, summary, error: loaderError } =
+  const [searchParams, setSearchParams] = useSearchParams();
+  const {
+    report,
+    summary,
+    error: loaderError,
+    filters,
+    catalogItemOptions,
+  } =
     useLoaderData<Awaited<ReturnType<typeof LoaderFeedbacksInsightsReport>>>();
   const revalidator = useRevalidator();
   const fetcher = useFetcher<FeedbackInsightsReportActionData>();
@@ -69,10 +82,41 @@ export default function FeedbacksInsightsReport() {
     }
   }, [fetcher.state, fetcher.data, revalidator]);
 
-  const handleRefreshClick = () => {
+  const handleRefreshSelected = () => {
+    const form = new FormData();
+    form.set('intent', INTENT_FEEDBACK_RUN_IA);
+    form.set('scope_type', filters.scope_type);
+
+    if (filters.catalog_item_id) {
+      form.set('catalog_item_id', filters.catalog_item_id);
+    }
+
+    fetcher.submit(form, { method: 'post' });
+  };
+
+  const handleRefreshAll = () => {
     const form = new FormData();
     form.set('intent', INTENT_FEEDBACK_RUN_IA);
     fetcher.submit(form, { method: 'post' });
+  };
+
+  const handleScopeChange = (scope: InsightScopeOption) => {
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set('scope_type', scope);
+    nextParams.delete('catalog_item_id');
+    setSearchParams(nextParams);
+  };
+
+  const handleCatalogItemChange = (catalogItemId: string) => {
+    const nextParams = new URLSearchParams(searchParams);
+
+    if (catalogItemId) {
+      nextParams.set('catalog_item_id', catalogItemId);
+    } else {
+      nextParams.delete('catalog_item_id');
+    }
+
+    setSearchParams(nextParams);
   };
 
   if (refreshing && !report && !summary && !loaderError) {
@@ -91,7 +135,7 @@ export default function FeedbacksInsightsReport() {
     return (
       <InsightsReportEmptyState
         refreshing={refreshing}
-        onRefresh={handleRefreshClick}
+        onRefresh={handleRefreshSelected}
       />
     );
   }
@@ -117,7 +161,13 @@ export default function FeedbacksInsightsReport() {
         <InsightsReportHeaderSection
           updatedLabel={updatedLabel}
           refreshing={refreshing}
-          onRefresh={handleRefreshClick}
+          selectedScope={filters.scope_type}
+          selectedCatalogItemId={filters.catalog_item_id ?? ''}
+          catalogItemOptions={catalogItemOptions}
+          onScopeChange={handleScopeChange}
+          onCatalogItemChange={handleCatalogItemChange}
+          onRefreshSelected={handleRefreshSelected}
+          onRefreshAll={handleRefreshAll}
         />
 
         <InsightsReportMoodSection

--- a/pages/user/feedbacks/insights/feedbackInsightsReport.tsx
+++ b/pages/user/feedbacks/insights/feedbackInsightsReport.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   useFetcher,
   useLoaderData,
@@ -12,7 +12,6 @@ import type { LoaderFeedbacksInsightsReport } from 'src/routes/loaders/loaderFee
 import { INTENT_FEEDBACK_RUN_IA } from 'lib/constants/routes/intents';
 import InsightsReportLoadingState from 'components/user/pages/feedbacksInsightsReport/InsightsReportLoadingState';
 import InsightsReportErrorState from 'components/user/pages/feedbacksInsightsReport/InsightsReportErrorState';
-import InsightsReportEmptyState from 'components/user/pages/feedbacksInsightsReport/InsightsReportEmptyState';
 import InsightsReportHeaderSection from 'components/user/pages/feedbacksInsightsReport/InsightsReportHeaderSection';
 import InsightsReportMoodSection from 'components/user/pages/feedbacksInsightsReport/InsightsReportMoodSection';
 import InsightsReportSummarySection from 'components/user/pages/feedbacksInsightsReport/InsightsReportSummarySection';
@@ -72,6 +71,7 @@ export default function FeedbacksInsightsReport() {
   const revalidator = useRevalidator();
   const fetcher = useFetcher<FeedbackInsightsReportActionData>();
   const shouldRevalidateRef = useRef(false);
+  const [dismissedErrorKey, setDismissedErrorKey] = useState<string | null>(null);
 
   const refreshing =
     fetcher.state !== 'idle' || revalidator.state === 'loading';
@@ -80,6 +80,10 @@ export default function FeedbacksInsightsReport() {
     fetcher.data?.errorCode === 'insufficient_feedbacks_for_analysis'
       ? 'warning'
       : 'error';
+  const errorKey = error
+    ? `${fetcher.data?.errorCode ?? 'generic'}:${error}`
+    : null;
+  const showErrorPopup = Boolean(errorKey && dismissedErrorKey !== errorKey);
 
   useEffect(() => {
     const finishedRequest = fetcher.state === 'idle' && shouldRevalidateRef.current;
@@ -104,6 +108,7 @@ export default function FeedbacksInsightsReport() {
       form.set('catalog_item_id', filters.catalog_item_id);
     }
 
+    setDismissedErrorKey(null);
     shouldRevalidateRef.current = true;
     fetcher.submit(form, { method: 'post' });
   };
@@ -111,6 +116,7 @@ export default function FeedbacksInsightsReport() {
   const handleRefreshAll = () => {
     const form = new FormData();
     form.set('intent', INTENT_FEEDBACK_RUN_IA);
+    setDismissedErrorKey(null);
     shouldRevalidateRef.current = true;
     fetcher.submit(form, { method: 'post' });
   };
@@ -138,22 +144,9 @@ export default function FeedbacksInsightsReport() {
     return <InsightsReportLoadingState />;
   }
 
-  if (error) {
-    return <InsightsReportErrorState error={error} variant={errorVariant} />;
-  }
-
   const hasContent =
     report && ((report.summary && report.summary.trim().length > 0) ||
       (report.recommendations && report.recommendations.length > 0));
-
-  if (!hasContent) {
-    return (
-      <InsightsReportEmptyState
-        refreshing={refreshing}
-        onRefresh={handleRefreshSelected}
-      />
-    );
-  }
 
   const updatedLabel =
     report?.updatedAt != null
@@ -171,38 +164,63 @@ export default function FeedbacksInsightsReport() {
     total > 0 ? Math.round((summary!.sentiments.negative / total) * 100) : 0;
 
   return (
-    <div className="font-work-sans space-y-6 pb-8">
-      <div className="relative overflow-hidden rounded-2xl border border-(--quaternary-color)/10 bg-gradient-to-br from-(--bg-secondary) to-(--sixth-color) p-6 glass-card space-y-6">
-        <InsightsReportHeaderSection
-          updatedLabel={updatedLabel}
-          refreshing={refreshing}
-          selectedScope={filters.scope_type}
-          selectedCatalogItemId={filters.catalog_item_id ?? ''}
-          catalogItemOptions={catalogItemOptions}
-          onScopeChange={handleScopeChange}
-          onCatalogItemChange={handleCatalogItemChange}
-          onRefreshSelected={handleRefreshSelected}
-          onRefreshAll={handleRefreshAll}
-        />
-
-        <InsightsReportMoodSection
-          mood={mood}
-          summary={summary}
-          positivePct={positivePct}
-          neutralPct={neutralPct}
-          negativePct={negativePct}
-        />
-
-        {report?.summary && report.summary.trim().length > 0 && (
-          <InsightsReportSummarySection summaryText={report.summary} />
-        )}
-
-        {report?.recommendations && report.recommendations.length > 0 && (
-          <InsightsReportRecommendationsSection
-            recommendations={report.recommendations}
+    <>
+      <div className="font-work-sans space-y-6 pb-8">
+        <div className="relative overflow-hidden rounded-2xl border border-(--quaternary-color)/10 bg-gradient-to-br from-(--bg-secondary) to-(--sixth-color) p-6 glass-card space-y-6">
+          <InsightsReportHeaderSection
+            updatedLabel={updatedLabel}
+            refreshing={refreshing}
+            selectedScope={filters.scope_type}
+            selectedCatalogItemId={filters.catalog_item_id ?? ''}
+            catalogItemOptions={catalogItemOptions}
+            onScopeChange={handleScopeChange}
+            onCatalogItemChange={handleCatalogItemChange}
+            onRefreshSelected={handleRefreshSelected}
+            onRefreshAll={handleRefreshAll}
           />
-        )}
+
+          <InsightsReportMoodSection
+            mood={mood}
+            summary={summary}
+            positivePct={positivePct}
+            neutralPct={neutralPct}
+            negativePct={negativePct}
+          />
+
+          {!hasContent && (
+            <div className="rounded-2xl border border-(--quaternary-color)/20 bg-(--bg-primary)/60 p-5">
+              <h3 className="font-montserrat text-base font-semibold text-(--text-primary)">
+                Ainda não há relatório para este escopo
+              </h3>
+              <p className="mt-2 text-sm text-(--text-secondary)">
+                Selecione outro escopo no filtro acima ou clique em
+                {' '}
+                <span className="font-semibold text-(--text-primary)">Atualizar escopo selecionado</span>
+                {' '}
+                para gerar um novo relatório.
+              </p>
+            </div>
+          )}
+
+          {report?.summary && report.summary.trim().length > 0 && (
+            <InsightsReportSummarySection summaryText={report.summary} />
+          )}
+
+          {report?.recommendations && report.recommendations.length > 0 && (
+            <InsightsReportRecommendationsSection
+              recommendations={report.recommendations}
+            />
+          )}
+        </div>
       </div>
-    </div>
+
+      {showErrorPopup && error && (
+        <InsightsReportErrorState
+          error={error}
+          variant={errorVariant}
+          onClose={() => setDismissedErrorKey(errorKey)}
+        />
+      )}
+    </>
   );
 }

--- a/pages/user/feedbacks/insights/feedbackInsightsReport.tsx
+++ b/pages/user/feedbacks/insights/feedbackInsightsReport.tsx
@@ -65,6 +65,7 @@ export default function FeedbacksInsightsReport() {
     summary,
     error: loaderError,
     filters,
+    availableScopes,
     catalogItemOptions,
   } =
     useLoaderData<Awaited<ReturnType<typeof LoaderFeedbacksInsightsReport>>>();
@@ -219,6 +220,7 @@ export default function FeedbacksInsightsReport() {
           <InsightsReportHeaderSection
             updatedLabel={updatedLabel}
             refreshing={refreshing}
+            availableScopes={availableScopes}
             selectedScope={filters.scope_type}
             selectedCatalogItemId={filters.catalog_item_id ?? ''}
             catalogItemOptions={catalogItemOptions}

--- a/pages/user/feedbacks/insights/feedbackInsightsReport.tsx
+++ b/pages/user/feedbacks/insights/feedbackInsightsReport.tsx
@@ -65,6 +65,7 @@ export default function FeedbacksInsightsReport() {
     summary,
     error: loaderError,
     filters,
+    analysisGuard,
     availableScopes,
     catalogItemOptions,
   } =
@@ -75,7 +76,9 @@ export default function FeedbacksInsightsReport() {
   const [dismissedErrorKey, setDismissedErrorKey] = useState<string | null>(null);
   const [localError, setLocalError] = useState<{
     error: string;
-    errorCode: 'item_selection_required';
+    errorCode:
+      | 'item_selection_required'
+      | 'collecting_data_required_for_analysis';
   } | null>(null);
 
   const refreshing =
@@ -84,6 +87,7 @@ export default function FeedbacksInsightsReport() {
   const errorCode = localError?.errorCode ?? fetcher.data?.errorCode;
   const errorVariant =
     errorCode === 'insufficient_feedbacks_for_analysis' ||
+      errorCode === 'collecting_data_required_for_analysis' ||
       errorCode === 'item_selection_required'
       ? 'warning'
       : 'error';
@@ -132,6 +136,17 @@ export default function FeedbacksInsightsReport() {
   }, [fetcher.state, fetcher.data?.ok, revalidator]);
 
   const handleRefreshSelected = () => {
+    if (!analysisGuard.canAnalyze) {
+      setLocalError({
+        error:
+          analysisGuard.message ??
+          'Preencha as informações da empresa para liberar a análise.',
+        errorCode: 'collecting_data_required_for_analysis',
+      });
+      setDismissedErrorKey(null);
+      return;
+    }
+
     if (filters.scope_type !== 'COMPANY' && !filters.catalog_item_id) {
       setLocalError({
         error: 'Selecione um item para analisar este escopo.',
@@ -220,6 +235,8 @@ export default function FeedbacksInsightsReport() {
           <InsightsReportHeaderSection
             updatedLabel={updatedLabel}
             refreshing={refreshing}
+            canAnalyze={analysisGuard.canAnalyze}
+            analysisBlockedMessage={analysisGuard.message}
             availableScopes={availableScopes}
             selectedScope={filters.scope_type}
             selectedCatalogItemId={filters.catalog_item_id ?? ''}

--- a/pages/user/feedbacks/insights/feedbackInsightsReport.tsx
+++ b/pages/user/feedbacks/insights/feedbackInsightsReport.tsx
@@ -72,18 +72,49 @@ export default function FeedbacksInsightsReport() {
   const fetcher = useFetcher<FeedbackInsightsReportActionData>();
   const shouldRevalidateRef = useRef(false);
   const [dismissedErrorKey, setDismissedErrorKey] = useState<string | null>(null);
+  const [localError, setLocalError] = useState<{
+    error: string;
+    errorCode: 'item_selection_required';
+  } | null>(null);
 
   const refreshing =
     fetcher.state !== 'idle' || revalidator.state === 'loading';
-  const error = fetcher.data?.error ?? loaderError;
+  const error = localError?.error ?? fetcher.data?.error ?? loaderError;
+  const errorCode = localError?.errorCode ?? fetcher.data?.errorCode;
   const errorVariant =
-    fetcher.data?.errorCode === 'insufficient_feedbacks_for_analysis'
+    errorCode === 'insufficient_feedbacks_for_analysis' ||
+      errorCode === 'item_selection_required'
       ? 'warning'
       : 'error';
   const errorKey = error
-    ? `${fetcher.data?.errorCode ?? 'generic'}:${error}`
+    ? `${errorCode ?? 'generic'}:${error}`
     : null;
   const showErrorPopup = Boolean(errorKey && dismissedErrorKey !== errorKey);
+
+  useEffect(() => {
+    if (filters.scope_type === 'COMPANY') {
+      return;
+    }
+
+    const scopeItems = catalogItemOptions.filter((item) => item.kind === filters.scope_type);
+    const hasSelectedItem =
+      Boolean(filters.catalog_item_id) &&
+      scopeItems.some((item) => item.id === filters.catalog_item_id);
+
+    if (hasSelectedItem || scopeItems.length === 0) {
+      return;
+    }
+
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set('catalog_item_id', scopeItems[0].id);
+    setSearchParams(nextParams, { replace: true });
+  }, [
+    filters.scope_type,
+    filters.catalog_item_id,
+    catalogItemOptions,
+    searchParams,
+    setSearchParams,
+  ]);
 
   useEffect(() => {
     const finishedRequest = fetcher.state === 'idle' && shouldRevalidateRef.current;
@@ -100,6 +131,15 @@ export default function FeedbacksInsightsReport() {
   }, [fetcher.state, fetcher.data?.ok, revalidator]);
 
   const handleRefreshSelected = () => {
+    if (filters.scope_type !== 'COMPANY' && !filters.catalog_item_id) {
+      setLocalError({
+        error: 'Selecione um item para analisar este escopo.',
+        errorCode: 'item_selection_required',
+      });
+      setDismissedErrorKey(null);
+      return;
+    }
+
     const form = new FormData();
     form.set('intent', INTENT_FEEDBACK_RUN_IA);
     form.set('scope_type', filters.scope_type);
@@ -108,14 +148,7 @@ export default function FeedbacksInsightsReport() {
       form.set('catalog_item_id', filters.catalog_item_id);
     }
 
-    setDismissedErrorKey(null);
-    shouldRevalidateRef.current = true;
-    fetcher.submit(form, { method: 'post' });
-  };
-
-  const handleRefreshAll = () => {
-    const form = new FormData();
-    form.set('intent', INTENT_FEEDBACK_RUN_IA);
+    setLocalError(null);
     setDismissedErrorKey(null);
     shouldRevalidateRef.current = true;
     fetcher.submit(form, { method: 'post' });
@@ -124,7 +157,21 @@ export default function FeedbacksInsightsReport() {
   const handleScopeChange = (scope: InsightScopeOption) => {
     const nextParams = new URLSearchParams(searchParams);
     nextParams.set('scope_type', scope);
-    nextParams.delete('catalog_item_id');
+
+    if (scope === 'COMPANY') {
+      nextParams.delete('catalog_item_id');
+    } else {
+      const scopeItems = catalogItemOptions.filter((item) => item.kind === scope);
+
+      if (scopeItems.length > 0) {
+        nextParams.set('catalog_item_id', scopeItems[0].id);
+      } else {
+        nextParams.delete('catalog_item_id');
+      }
+    }
+
+    setLocalError(null);
+    setDismissedErrorKey(null);
     setSearchParams(nextParams);
   };
 
@@ -137,6 +184,8 @@ export default function FeedbacksInsightsReport() {
       nextParams.delete('catalog_item_id');
     }
 
+    setLocalError(null);
+    setDismissedErrorKey(null);
     setSearchParams(nextParams);
   };
 
@@ -176,7 +225,6 @@ export default function FeedbacksInsightsReport() {
             onScopeChange={handleScopeChange}
             onCatalogItemChange={handleCatalogItemChange}
             onRefreshSelected={handleRefreshSelected}
-            onRefreshAll={handleRefreshAll}
           />
 
           <InsightsReportMoodSection
@@ -218,7 +266,13 @@ export default function FeedbacksInsightsReport() {
         <InsightsReportErrorState
           error={error}
           variant={errorVariant}
-          onClose={() => setDismissedErrorKey(errorKey)}
+          onClose={() => {
+            if (localError) {
+              setLocalError(null);
+            }
+
+            setDismissedErrorKey(errorKey);
+          }}
         />
       )}
     </>

--- a/pages/user/feedbacks/insights/feedbackInsightsReport.tsx
+++ b/pages/user/feedbacks/insights/feedbackInsightsReport.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import {
   useFetcher,
   useLoaderData,
@@ -71,16 +71,25 @@ export default function FeedbacksInsightsReport() {
     useLoaderData<Awaited<ReturnType<typeof LoaderFeedbacksInsightsReport>>>();
   const revalidator = useRevalidator();
   const fetcher = useFetcher<FeedbackInsightsReportActionData>();
+  const shouldRevalidateRef = useRef(false);
 
   const refreshing =
     fetcher.state !== 'idle' || revalidator.state === 'loading';
   const error = fetcher.data?.error ?? loaderError;
 
   useEffect(() => {
-    if (fetcher.state === 'idle' && fetcher.data?.ok) {
+    const finishedRequest = fetcher.state === 'idle' && shouldRevalidateRef.current;
+
+    if (!finishedRequest) {
+      return;
+    }
+
+    shouldRevalidateRef.current = false;
+
+    if (fetcher.data?.ok) {
       revalidator.revalidate();
     }
-  }, [fetcher.state, fetcher.data, revalidator]);
+  }, [fetcher.state, fetcher.data?.ok, revalidator]);
 
   const handleRefreshSelected = () => {
     const form = new FormData();
@@ -91,12 +100,14 @@ export default function FeedbacksInsightsReport() {
       form.set('catalog_item_id', filters.catalog_item_id);
     }
 
+    shouldRevalidateRef.current = true;
     fetcher.submit(form, { method: 'post' });
   };
 
   const handleRefreshAll = () => {
     const form = new FormData();
     form.set('intent', INTENT_FEEDBACK_RUN_IA);
+    shouldRevalidateRef.current = true;
     fetcher.submit(form, { method: 'post' });
   };
 

--- a/pages/user/feedbacks/insights/feedbackInsightsReport.tsx
+++ b/pages/user/feedbacks/insights/feedbackInsightsReport.tsx
@@ -76,6 +76,10 @@ export default function FeedbacksInsightsReport() {
   const refreshing =
     fetcher.state !== 'idle' || revalidator.state === 'loading';
   const error = fetcher.data?.error ?? loaderError;
+  const errorVariant =
+    fetcher.data?.errorCode === 'insufficient_feedbacks_for_analysis'
+      ? 'warning'
+      : 'error';
 
   useEffect(() => {
     const finishedRequest = fetcher.state === 'idle' && shouldRevalidateRef.current;
@@ -135,7 +139,7 @@ export default function FeedbacksInsightsReport() {
   }
 
   if (error) {
-    return <InsightsReportErrorState error={error} />;
+    return <InsightsReportErrorState error={error} variant={errorVariant} />;
   }
 
   const hasContent =

--- a/pages/user/feedbacks/insights/ui.types.ts
+++ b/pages/user/feedbacks/insights/ui.types.ts
@@ -5,5 +5,7 @@
 export type FeedbackInsightsReportActionData = {
   ok?: boolean;
   error?: string;
-  errorCode?: 'insufficient_feedbacks_for_analysis';
+  errorCode?:
+    | 'insufficient_feedbacks_for_analysis'
+    | 'item_selection_required';
 };

--- a/pages/user/feedbacks/insights/ui.types.ts
+++ b/pages/user/feedbacks/insights/ui.types.ts
@@ -7,5 +7,6 @@ export type FeedbackInsightsReportActionData = {
   error?: string;
   errorCode?:
     | 'insufficient_feedbacks_for_analysis'
+    | 'collecting_data_required_for_analysis'
     | 'item_selection_required';
 };

--- a/pages/user/feedbacks/insights/ui.types.ts
+++ b/pages/user/feedbacks/insights/ui.types.ts
@@ -5,4 +5,5 @@
 export type FeedbackInsightsReportActionData = {
   ok?: boolean;
   error?: string;
+  errorCode?: 'insufficient_feedbacks_for_analysis';
 };

--- a/src/routes/actions/actionCollectingData.test.ts
+++ b/src/routes/actions/actionCollectingData.test.ts
@@ -186,4 +186,75 @@ describe('ActionCollectingData', () => {
       catalog_departments: [],
     });
   });
+
+  it('envia perguntas padrão da empresa quando company_feedback_questions é informado', async () => {
+    mockUpdateCollectingDataEnterprise.mockResolvedValue({
+      id: 'collecting-id',
+      enterprise_id: 'enterprise-id',
+      company_objective: null,
+      analytics_goal: null,
+      business_summary: null,
+      main_products_or_services: null,
+      uses_company_products: false,
+      uses_company_services: false,
+      uses_company_departments: false,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+
+    await ActionCollectingData(
+      createArgs({
+        uses_company_products: 'false',
+        uses_company_services: 'false',
+        uses_company_departments: 'false',
+        company_feedback_questions: JSON.stringify([
+          {
+            question_order: 1,
+            question_text: 'Pergunta 1',
+            is_active: true,
+          },
+          {
+            question_order: 2,
+            question_text: 'Pergunta 2',
+            is_active: true,
+          },
+          {
+            question_order: 3,
+            question_text: 'Pergunta 3',
+            is_active: true,
+          },
+        ]),
+      }),
+    );
+
+    expect(mockUpdateCollectingDataEnterprise).toHaveBeenCalledWith({
+      company_objective: null,
+      analytics_goal: null,
+      business_summary: null,
+      main_products_or_services: null,
+      uses_company_products: false,
+      uses_company_services: false,
+      uses_company_departments: false,
+      catalog_products: [],
+      catalog_services: [],
+      catalog_departments: [],
+      company_feedback_questions: [
+        {
+          question_order: 1,
+          question_text: 'Pergunta 1',
+          is_active: true,
+        },
+        {
+          question_order: 2,
+          question_text: 'Pergunta 2',
+          is_active: true,
+        },
+        {
+          question_order: 3,
+          question_text: 'Pergunta 3',
+          is_active: true,
+        },
+      ],
+    });
+  });
 });

--- a/src/routes/actions/actionCollectingData.ts
+++ b/src/routes/actions/actionCollectingData.ts
@@ -1,4 +1,7 @@
-import type { CatalogItemInput } from 'lib/interfaces/entities/enterprise.entity';
+import type {
+  CatalogItemInput,
+  CompanyFeedbackQuestionInput,
+} from 'lib/interfaces/entities/enterprise.entity';
 import { ServiceUpdateCollectingDataEnterprise } from 'src/services/serviceEnterprise';
 import type { ActionFunctionArgs } from 'react-router-dom';
 
@@ -87,6 +90,58 @@ function parseCatalogItemsField(
   }
 }
 
+function parseCompanyFeedbackQuestionsField(
+  raw: FormDataEntryValue | null,
+): CompanyFeedbackQuestionInput[] | undefined {
+  if (raw === null) return undefined;
+
+  const text = String(raw ?? '').trim();
+  if (!text) return [];
+
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed
+      .slice(0, 3)
+      .map((item, index) => {
+        if (!item || typeof item !== 'object') return null;
+
+        const candidate = item as {
+          question_order?: unknown;
+          question_text?: unknown;
+          is_active?: unknown;
+        };
+
+        const questionOrderRaw = Number(candidate.question_order);
+        const question_order =
+          Number.isInteger(questionOrderRaw) &&
+          questionOrderRaw >= 1 &&
+          questionOrderRaw <= 3
+            ? (questionOrderRaw as 1 | 2 | 3)
+            : ((index + 1) as 1 | 2 | 3);
+
+        const question_text =
+          typeof candidate.question_text === 'string'
+            ? candidate.question_text.trim()
+            : '';
+
+        if (!question_text) return null;
+
+        return {
+          question_order,
+          question_text,
+          is_active: candidate.is_active === false ? false : true,
+        };
+      })
+      .filter(
+        (item): item is CompanyFeedbackQuestionInput => item !== null,
+      );
+  } catch {
+    return [];
+  }
+}
+
 export async function ActionCollectingData({ request }: ActionFunctionArgs) {
   const form = await request.formData();
 
@@ -111,6 +166,9 @@ export async function ActionCollectingData({ request }: ActionFunctionArgs) {
   );
   const catalogDepartmentsFromForm = parseCatalogItemsField(
     form.get('catalog_departments'),
+  );
+  const companyFeedbackQuestionsFromForm = parseCompanyFeedbackQuestionsField(
+    form.get('company_feedback_questions'),
   );
 
   const legacyProducts = parseLegacyProductsText(main_products_or_services_text);
@@ -143,6 +201,9 @@ export async function ActionCollectingData({ request }: ActionFunctionArgs) {
       catalog_products,
       catalog_services,
       catalog_departments,
+      ...(companyFeedbackQuestionsFromForm !== undefined
+        ? { company_feedback_questions: companyFeedbackQuestionsFromForm }
+        : {}),
     });
 
     return new Response(JSON.stringify({ collecting }), {

--- a/src/routes/actions/actionFeedbackInsightsReport.ts
+++ b/src/routes/actions/actionFeedbackInsightsReport.ts
@@ -56,6 +56,7 @@ export async function ActionFeedbackInsightsReport({
     if (typedError.code === 'insufficient_feedbacks_for_analysis') {
       return new Response(
         JSON.stringify({
+          errorCode: 'insufficient_feedbacks_for_analysis',
           error:
             'Há poucos feedbacks neste contexto para uma análise relevante. É necessário no mínimo 10 feedbacks.',
         }),

--- a/src/routes/actions/actionFeedbackInsightsReport.ts
+++ b/src/routes/actions/actionFeedbackInsightsReport.ts
@@ -2,6 +2,22 @@ import type { ActionFunctionArgs } from 'react-router-dom';
 import { ServiceRunFeedbackIAAnalysis } from 'src/services/serviceFeedbacks';
 import { INTENT_FEEDBACK_RUN_IA } from 'lib/constants/routes/intents';
 import { ACTION_ERROR_INVALID_INTENT } from 'lib/constants/routes/errors';
+import type { FeedbackInsightScopeType } from 'lib/interfaces/domain/feedback.domain';
+
+function parseScopeType(value: FormDataEntryValue | null): FeedbackInsightScopeType | undefined {
+  const normalized = String(value ?? '').trim().toUpperCase();
+
+  if (
+    normalized === 'COMPANY' ||
+    normalized === 'PRODUCT' ||
+    normalized === 'SERVICE' ||
+    normalized === 'DEPARTMENT'
+  ) {
+    return normalized;
+  }
+
+  return undefined;
+}
 
 export async function ActionFeedbackInsightsReport({
   request,
@@ -16,8 +32,14 @@ export async function ActionFeedbackInsightsReport({
     });
   }
 
+  const scope_type = parseScopeType(form.get('scope_type'));
+  const catalog_item_id = String(form.get('catalog_item_id') ?? '').trim() || undefined;
+
   try {
-    await ServiceRunFeedbackIAAnalysis();
+    await ServiceRunFeedbackIAAnalysis({
+      scope_type,
+      catalog_item_id,
+    });
 
     return new Response(JSON.stringify({ ok: true }), {
       status: 200,

--- a/src/routes/actions/actionFeedbackInsightsReport.ts
+++ b/src/routes/actions/actionFeedbackInsightsReport.ts
@@ -40,6 +40,19 @@ export async function ActionFeedbackInsightsReport({
   const scope_type = parseScopeType(form.get('scope_type'));
   const catalog_item_id = String(form.get('catalog_item_id') ?? '').trim() || undefined;
 
+  if (scope_type && scope_type !== 'COMPANY' && !catalog_item_id) {
+    return new Response(
+      JSON.stringify({
+        errorCode: 'item_selection_required',
+        error: 'Selecione um item para analisar este escopo.',
+      }),
+      {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  }
+
   try {
     await ServiceRunFeedbackIAAnalysis({
       scope_type,

--- a/src/routes/actions/actionFeedbackInsightsReport.ts
+++ b/src/routes/actions/actionFeedbackInsightsReport.ts
@@ -4,6 +4,11 @@ import { INTENT_FEEDBACK_RUN_IA } from 'lib/constants/routes/intents';
 import { ACTION_ERROR_INVALID_INTENT } from 'lib/constants/routes/errors';
 import type { FeedbackInsightScopeType } from 'lib/interfaces/domain/feedback.domain';
 
+type HttpActionError = Error & {
+  status?: number;
+  code?: string;
+};
+
 function parseScopeType(value: FormDataEntryValue | null): FeedbackInsightScopeType | undefined {
   const normalized = String(value ?? '').trim().toUpperCase();
 
@@ -45,7 +50,22 @@ export async function ActionFeedbackInsightsReport({
       status: 200,
       headers: { 'Content-Type': 'application/json' },
     });
-  } catch {
+  } catch (error) {
+    const typedError = error as HttpActionError;
+
+    if (typedError.code === 'insufficient_feedbacks_for_analysis') {
+      return new Response(
+        JSON.stringify({
+          error:
+            'Há poucos feedbacks neste contexto para uma análise relevante. É necessário no mínimo 10 feedbacks.',
+        }),
+        {
+          status: 422,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }
+
     return new Response(
       JSON.stringify({ error: 'Erro ao atualizar insights com IA' }),
       {

--- a/src/routes/actions/actionFeedbackInsightsReport.ts
+++ b/src/routes/actions/actionFeedbackInsightsReport.ts
@@ -80,6 +80,20 @@ export async function ActionFeedbackInsightsReport({
       );
     }
 
+    if (typedError.code === 'collecting_data_required_for_analysis') {
+      return new Response(
+        JSON.stringify({
+          errorCode: 'collecting_data_required_for_analysis',
+          error:
+            'Para analisar os feedbacks, preencha as informações da empresa em Editar > Configuração de Coleta de Dados.',
+        }),
+        {
+          status: 422,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }
+
     return new Response(
       JSON.stringify({ error: 'Erro ao atualizar insights com IA' }),
       {

--- a/src/routes/actions/actionPublicQrCodeFeedback.test.ts
+++ b/src/routes/actions/actionPublicQrCodeFeedback.test.ts
@@ -9,6 +9,21 @@ vi.mock('src/services/serviceFeedbackQRCode', () => ({
 
 const mockServiceSubmitQrcodeFeedback = vi.mocked(ServiceSubmitQrcodeFeedback);
 
+const defaultAnswers = [
+  {
+    question_id: 'aaaaaaa1-aaaa-4aaa-8aaa-aaaaaaaaaaa1',
+    answer_value: 'BOA',
+  },
+  {
+    question_id: 'aaaaaaa2-aaaa-4aaa-8aaa-aaaaaaaaaaa2',
+    answer_value: 'OTIMA',
+  },
+  {
+    question_id: 'aaaaaaa3-aaaa-4aaa-8aaa-aaaaaaaaaaa3',
+    answer_value: 'MEDIANA',
+  },
+] as const;
+
 function createRequest(body: Record<string, string | undefined>) {
   const formData = new URLSearchParams();
 
@@ -53,6 +68,7 @@ describe('ActionPublicQrCodeFeedback', () => {
         catalog_item_id: '33333333-3333-4333-8333-333333333333',
         message: 'Ótimo produto',
         rating: '5',
+        answers: JSON.stringify(defaultAnswers),
       }),
     );
 
@@ -63,6 +79,7 @@ describe('ActionPublicQrCodeFeedback', () => {
       catalog_item_id: '33333333-3333-4333-8333-333333333333',
       message: 'Ótimo produto',
       rating: 5,
+      answers: defaultAnswers,
       channel: 'QRCODE',
       customer_name: undefined,
       customer_email: undefined,
@@ -87,6 +104,7 @@ describe('ActionPublicQrCodeFeedback', () => {
         collection_point_id: '22222222-2222-4222-8222-222222222222',
         message: 'Teste',
         rating: '5',
+        answers: JSON.stringify(defaultAnswers),
       }),
     );
 
@@ -125,6 +143,7 @@ describe('ActionPublicQrCodeFeedback', () => {
         collection_point_id: '22222222-2222-4222-8222-222222222222',
         message: 'Primeiro envio',
         rating: '5',
+        answers: JSON.stringify(defaultAnswers),
       }),
     );
 
@@ -134,6 +153,7 @@ describe('ActionPublicQrCodeFeedback', () => {
         collection_point_id: '22222222-2222-4222-8222-222222222222',
         message: 'Segundo envio mesmo QR',
         rating: '4',
+        answers: JSON.stringify(defaultAnswers),
       }),
     );
 
@@ -173,6 +193,7 @@ describe('ActionPublicQrCodeFeedback', () => {
         collection_point_id: '22222222-2222-4222-8222-222222222222',
         message: 'Feedback QR 1',
         rating: '5',
+        answers: JSON.stringify(defaultAnswers),
       }),
     );
 
@@ -182,6 +203,7 @@ describe('ActionPublicQrCodeFeedback', () => {
         collection_point_id: '44444444-4444-4444-8444-444444444444',
         message: 'Feedback QR 2',
         rating: '5',
+        answers: JSON.stringify(defaultAnswers),
       }),
     );
 

--- a/src/routes/actions/actionPublicQrCodeFeedback.ts
+++ b/src/routes/actions/actionPublicQrCodeFeedback.ts
@@ -1,11 +1,83 @@
 import type { ActionFunctionArgs } from 'react-router-dom';
 import { ServiceSubmitQrcodeFeedback } from 'src/services/serviceFeedbackQRCode';
 import { getPublicQrFeedbackErrorMessage } from 'lib/utils/publicQrFeedbackErrorMessage';
+import type {
+  FeedbackAnswerValue,
+  FeedbackQuestionAnswerInput,
+} from 'lib/interfaces/contracts/qrcode.contract';
 
 type HttpError = Error & {
   status?: number;
   code?: string;
 };
+
+const ALLOWED_ANSWER_VALUES: FeedbackAnswerValue[] = [
+  'PESSIMO',
+  'RUIM',
+  'MEDIANA',
+  'BOA',
+  'OTIMA',
+];
+
+function parseAnswersInput(raw: string): FeedbackQuestionAnswerInput[] | null {
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed) || parsed.length !== 3) {
+      return null;
+    }
+
+    const normalized = parsed
+      .map((item) => {
+        if (!item || typeof item !== 'object') return null;
+
+        const candidate = item as {
+          question_id?: unknown;
+          answer_value?: unknown;
+        };
+
+        const questionId =
+          typeof candidate.question_id === 'string'
+            ? candidate.question_id.trim()
+            : '';
+
+        const answerValue =
+          typeof candidate.answer_value === 'string'
+            ? candidate.answer_value.trim().toUpperCase()
+            : '';
+
+        if (
+          !questionId ||
+          !ALLOWED_ANSWER_VALUES.includes(answerValue as FeedbackAnswerValue)
+        ) {
+          return null;
+        }
+
+        return {
+          question_id: questionId,
+          answer_value: answerValue as FeedbackAnswerValue,
+        };
+      })
+      .filter(
+        (entry): entry is FeedbackQuestionAnswerInput =>
+          Boolean(entry?.question_id) && Boolean(entry?.answer_value),
+      );
+
+    if (normalized.length !== 3) {
+      return null;
+    }
+
+    const questionIds = normalized.map((entry) => entry.question_id);
+    if (new Set(questionIds).size !== 3) {
+      return null;
+    }
+
+    return normalized;
+  } catch {
+    return null;
+  }
+}
 
 export async function ActionPublicQrCodeFeedback({
   request,
@@ -17,9 +89,11 @@ export async function ActionPublicQrCodeFeedback({
   const catalog_item_id = String(form.get('catalog_item_id') ?? '').trim();
   const message = String(form.get('message') ?? '').trim();
   const rating = Number(form.get('rating') ?? 0);
+  const answersRaw = String(form.get('answers') ?? '').trim();
   const customer_name = String(form.get('customer_name') ?? '').trim();
   const customer_email = String(form.get('customer_email') ?? '').trim();
   const customer_gender_raw = String(form.get('customer_gender') ?? '').trim();
+  const answers = parseAnswersInput(answersRaw);
 
   if (!enterprise_id) {
     return new Response(
@@ -51,6 +125,16 @@ export async function ActionPublicQrCodeFeedback({
     );
   }
 
+  if (!answers) {
+    return new Response(
+      JSON.stringify({ error: 'Responda as 3 perguntas antes de enviar.' }),
+      {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  }
+
   try {
     await ServiceSubmitQrcodeFeedback({
       enterprise_id,
@@ -58,6 +142,7 @@ export async function ActionPublicQrCodeFeedback({
       catalog_item_id: catalog_item_id || undefined,
       message,
       rating,
+      answers,
       channel: 'QRCODE',
       customer_name: customer_name || undefined,
       customer_email: customer_email || undefined,

--- a/src/routes/load/loadFeedbackAnalysis.ts
+++ b/src/routes/load/loadFeedbackAnalysis.ts
@@ -1,8 +1,8 @@
 import { ServiceGetFeedbackAnalysis } from 'src/services/serviceFeedbacks';
 import type {
   FeedbackAnalysisItem,
+  FeedbackAnalysisOptions,
   FeedbackAnalysisSummary,
-  FeedbackSentiment,
 } from 'lib/interfaces/domain/feedback.domain';
 
 export type FeedbackAnalysisLoadData = {
@@ -11,9 +11,9 @@ export type FeedbackAnalysisLoadData = {
   error: string | null;
 };
 
-export async function loadFeedbackAnalysisData(options?: {
-  sentiment?: FeedbackSentiment;
-}): Promise<FeedbackAnalysisLoadData> {
+export async function loadFeedbackAnalysisData(
+  options?: FeedbackAnalysisOptions,
+): Promise<FeedbackAnalysisLoadData> {
   try {
     const response = await ServiceGetFeedbackAnalysis(options);
 

--- a/src/routes/load/loadFeedbackInsightsReport.ts
+++ b/src/routes/load/loadFeedbackInsightsReport.ts
@@ -1,5 +1,6 @@
 import type {
   FeedbackAnalysisSummary,
+  FeedbackInsightScopeType,
   FeedbackInsightsReportOptions,
   FeedbackInsightsReport,
 } from 'lib/interfaces/domain/feedback.domain';
@@ -16,46 +17,99 @@ type InsightsCatalogItemOption = {
 export type FeedbackInsightsReportLoadData = {
   report: FeedbackInsightsReport | null;
   summary: FeedbackAnalysisSummary | null;
+  availableScopes: FeedbackInsightScopeType[];
   catalogItemOptions: InsightsCatalogItemOption[];
+  filters: {
+    scope_type: FeedbackInsightScopeType;
+    catalog_item_id: string | null;
+  };
   error: string | null;
 };
 
 export async function loadFeedbackInsightsReportData(
   options?: FeedbackInsightsReportOptions,
 ): Promise<FeedbackInsightsReportLoadData> {
-  const [reportData, analysisData, collectingData] = await Promise.all([
-    ServiceGetFeedbackInsightsReport(options).catch(() => null),
-    loadFeedbackAnalysisData({
-      scope_type: options?.scope_type,
-      catalog_item_id: options?.catalog_item_id,
-    }),
-    ServiceGetCollectingDataEnterprise().catch(() => null),
-  ]);
+  const collectingData = await ServiceGetCollectingDataEnterprise().catch(() => null);
 
-  const catalogItemOptions: InsightsCatalogItemOption[] = [
-    ...(collectingData?.catalog_products ?? []).map((item) => ({
-      id: item.id,
-      name: item.name,
-      kind: 'PRODUCT' as const,
-    })),
-    ...(collectingData?.catalog_services ?? []).map((item) => ({
-      id: item.id,
-      name: item.name,
-      kind: 'SERVICE' as const,
-    })),
-    ...(collectingData?.catalog_departments ?? []).map((item) => ({
-      id: item.id,
-      name: item.name,
-      kind: 'DEPARTMENT' as const,
-    })),
-  ];
+  const availableScopes: FeedbackInsightScopeType[] = ['COMPANY'];
+  const catalogItemOptions: InsightsCatalogItemOption[] = [];
+
+  const productItems = collectingData?.catalog_products ?? [];
+  const serviceItems = collectingData?.catalog_services ?? [];
+  const departmentItems = collectingData?.catalog_departments ?? [];
+
+  if (collectingData?.uses_company_products && productItems.length > 0) {
+    availableScopes.push('PRODUCT');
+    catalogItemOptions.push(
+      ...productItems.map((item) => ({
+        id: item.id,
+        name: item.name,
+        kind: 'PRODUCT' as const,
+      })),
+    );
+  }
+
+  if (collectingData?.uses_company_services && serviceItems.length > 0) {
+    availableScopes.push('SERVICE');
+    catalogItemOptions.push(
+      ...serviceItems.map((item) => ({
+        id: item.id,
+        name: item.name,
+        kind: 'SERVICE' as const,
+      })),
+    );
+  }
+
+  if (collectingData?.uses_company_departments && departmentItems.length > 0) {
+    availableScopes.push('DEPARTMENT');
+    catalogItemOptions.push(
+      ...departmentItems.map((item) => ({
+        id: item.id,
+        name: item.name,
+        kind: 'DEPARTMENT' as const,
+      })),
+    );
+  }
+
+  const requestedScope = options?.scope_type ?? 'COMPANY';
+  const scope_type = availableScopes.includes(requestedScope)
+    ? requestedScope
+    : 'COMPANY';
+
+  let catalog_item_id: string | undefined;
+
+  if (scope_type !== 'COMPANY') {
+    const scopeItems = catalogItemOptions.filter((item) => item.kind === scope_type);
+    const requestedItem = options?.catalog_item_id;
+
+    catalog_item_id =
+      requestedItem && scopeItems.some((item) => item.id === requestedItem)
+        ? requestedItem
+        : scopeItems[0]?.id;
+  }
+
+  const [reportData, analysisData] = await Promise.all([
+    ServiceGetFeedbackInsightsReport({
+      scope_type,
+      catalog_item_id,
+    }).catch(() => null),
+    loadFeedbackAnalysisData({
+      scope_type,
+      catalog_item_id,
+    }),
+  ]);
 
   const hasError = reportData === null || analysisData.error !== null;
 
   return {
     report: reportData,
     summary: analysisData.summary,
+    availableScopes,
     catalogItemOptions,
+    filters: {
+      scope_type,
+      catalog_item_id: catalog_item_id ?? null,
+    },
     error: hasError ? 'Erro ao carregar relatório de insights' : null,
   };
 }

--- a/src/routes/load/loadFeedbackInsightsReport.ts
+++ b/src/routes/load/loadFeedbackInsightsReport.ts
@@ -1,27 +1,61 @@
 import type {
   FeedbackAnalysisSummary,
+  FeedbackInsightsReportOptions,
   FeedbackInsightsReport,
 } from 'lib/interfaces/domain/feedback.domain';
 import { ServiceGetFeedbackInsightsReport } from 'src/services/serviceFeedbacks';
 import { loadFeedbackAnalysisData } from 'src/routes/load/loadFeedbackAnalysis';
+import { ServiceGetCollectingDataEnterprise } from 'src/services/serviceEnterprise';
+
+type InsightsCatalogItemOption = {
+  id: string;
+  name: string;
+  kind: 'PRODUCT' | 'SERVICE' | 'DEPARTMENT';
+};
 
 export type FeedbackInsightsReportLoadData = {
   report: FeedbackInsightsReport | null;
   summary: FeedbackAnalysisSummary | null;
+  catalogItemOptions: InsightsCatalogItemOption[];
   error: string | null;
 };
 
-export async function loadFeedbackInsightsReportData(): Promise<FeedbackInsightsReportLoadData> {
-  const [reportData, analysisData] = await Promise.all([
-    ServiceGetFeedbackInsightsReport().catch(() => null),
-    loadFeedbackAnalysisData(),
+export async function loadFeedbackInsightsReportData(
+  options?: FeedbackInsightsReportOptions,
+): Promise<FeedbackInsightsReportLoadData> {
+  const [reportData, analysisData, collectingData] = await Promise.all([
+    ServiceGetFeedbackInsightsReport(options).catch(() => null),
+    loadFeedbackAnalysisData({
+      scope_type: options?.scope_type,
+      catalog_item_id: options?.catalog_item_id,
+    }),
+    ServiceGetCollectingDataEnterprise().catch(() => null),
   ]);
+
+  const catalogItemOptions: InsightsCatalogItemOption[] = [
+    ...(collectingData?.catalog_products ?? []).map((item) => ({
+      id: item.id,
+      name: item.name,
+      kind: 'PRODUCT' as const,
+    })),
+    ...(collectingData?.catalog_services ?? []).map((item) => ({
+      id: item.id,
+      name: item.name,
+      kind: 'SERVICE' as const,
+    })),
+    ...(collectingData?.catalog_departments ?? []).map((item) => ({
+      id: item.id,
+      name: item.name,
+      kind: 'DEPARTMENT' as const,
+    })),
+  ];
 
   const hasError = reportData === null || analysisData.error !== null;
 
   return {
     report: reportData,
     summary: analysisData.summary,
+    catalogItemOptions,
     error: hasError ? 'Erro ao carregar relatório de insights' : null,
   };
 }

--- a/src/routes/load/loadFeedbackInsightsReport.ts
+++ b/src/routes/load/loadFeedbackInsightsReport.ts
@@ -4,6 +4,7 @@ import type {
   FeedbackInsightsReportOptions,
   FeedbackInsightsReport,
 } from 'lib/interfaces/domain/feedback.domain';
+import type { CollectingDataEnterprise } from 'lib/interfaces/entities/enterprise.entity';
 import { ServiceGetFeedbackInsightsReport } from 'src/services/serviceFeedbacks';
 import { loadFeedbackAnalysisData } from 'src/routes/load/loadFeedbackAnalysis';
 import { ServiceGetCollectingDataEnterprise } from 'src/services/serviceEnterprise';
@@ -19,6 +20,10 @@ export type FeedbackInsightsReportLoadData = {
   summary: FeedbackAnalysisSummary | null;
   availableScopes: FeedbackInsightScopeType[];
   catalogItemOptions: InsightsCatalogItemOption[];
+  analysisGuard: {
+    canAnalyze: boolean;
+    message: string | null;
+  };
   filters: {
     scope_type: FeedbackInsightScopeType;
     catalog_item_id: string | null;
@@ -26,10 +31,23 @@ export type FeedbackInsightsReportLoadData = {
   error: string | null;
 };
 
+function hasRequiredEnterpriseInfo(collecting: CollectingDataEnterprise | null) {
+  if (!collecting) {
+    return false;
+  }
+
+  const hasCompanyObjective = String(collecting.company_objective ?? '').trim().length > 0;
+  const hasAnalyticsGoal = String(collecting.analytics_goal ?? '').trim().length > 0;
+  const hasBusinessSummary = String(collecting.business_summary ?? '').trim().length > 0;
+
+  return hasCompanyObjective && hasAnalyticsGoal && hasBusinessSummary;
+}
+
 export async function loadFeedbackInsightsReportData(
   options?: FeedbackInsightsReportOptions,
 ): Promise<FeedbackInsightsReportLoadData> {
   const collectingData = await ServiceGetCollectingDataEnterprise().catch(() => null);
+  const canAnalyze = hasRequiredEnterpriseInfo(collectingData);
 
   const availableScopes: FeedbackInsightScopeType[] = ['COMPANY'];
   const catalogItemOptions: InsightsCatalogItemOption[] = [];
@@ -106,6 +124,12 @@ export async function loadFeedbackInsightsReportData(
     summary: analysisData.summary,
     availableScopes,
     catalogItemOptions,
+    analysisGuard: {
+      canAnalyze,
+      message: canAnalyze
+        ? null
+        : 'Para analisar os feedbacks, preencha as informações da empresa em Editar > Configuração de Coleta de Dados.',
+    },
     filters: {
       scope_type,
       catalog_item_id: catalog_item_id ?? null,

--- a/src/routes/load/loadPublicQrCodeEnterprise.test.ts
+++ b/src/routes/load/loadPublicQrCodeEnterprise.test.ts
@@ -33,6 +33,7 @@ describe('loadPublicQrCodeEnterpriseData', () => {
       enterpriseName: '',
       itemName: null,
       itemKind: null,
+      questions: [],
       error: 'ID da empresa não encontrado na URL. Verifique o QR Code.',
     });
 
@@ -65,6 +66,7 @@ describe('loadPublicQrCodeEnterpriseData', () => {
       enterpriseName: 'Empresa X',
       itemName: 'Produto X',
       itemKind: 'PRODUCT',
+      questions: [],
       error: '',
     });
   });
@@ -83,6 +85,7 @@ describe('loadPublicQrCodeEnterpriseData', () => {
       enterpriseName: '',
       itemName: null,
       itemKind: null,
+      questions: [],
       error: 'Empresa não encontrada. Verifique se o QR Code é válido.',
     });
   });

--- a/src/routes/load/loadPublicQrCodeEnterprise.ts
+++ b/src/routes/load/loadPublicQrCodeEnterprise.ts
@@ -1,4 +1,5 @@
 import { ServiceGetEnterprisePublic } from 'src/services/serviceEnterprise';
+import type { FeedbackQuestionPublic } from 'lib/interfaces/contracts/qrcode.contract';
 
 export type PublicQrCodeEnterpriseLoadData = {
   enterpriseId: string | null;
@@ -7,6 +8,7 @@ export type PublicQrCodeEnterpriseLoadData = {
   enterpriseName: string;
   itemName: string | null;
   itemKind: 'PRODUCT' | 'SERVICE' | 'DEPARTMENT' | null;
+  questions: FeedbackQuestionPublic[];
   error: string;
 };
 
@@ -27,6 +29,7 @@ export async function loadPublicQrCodeEnterpriseData(
       enterpriseName: '',
       itemName: null,
       itemKind: null,
+      questions: [],
       error: 'ID da empresa não encontrado na URL. Verifique o QR Code.',
     };
   }
@@ -44,6 +47,7 @@ export async function loadPublicQrCodeEnterpriseData(
       enterpriseName: enterprise.name || 'Empresa',
       itemName: enterprise.item_name ?? null,
       itemKind: enterprise.item_kind ?? null,
+      questions: enterprise.questions ?? [],
       error: '',
     };
   } catch (err) {
@@ -56,6 +60,7 @@ export async function loadPublicQrCodeEnterpriseData(
       enterpriseName: '',
       itemName: null,
       itemKind: null,
+      questions: [],
       error: 'Empresa não encontrada. Verifique se o QR Code é válido.',
     };
   }

--- a/src/routes/loaders/loaderFeedbacksInsightsReport.ts
+++ b/src/routes/loaders/loaderFeedbacksInsightsReport.ts
@@ -1,7 +1,38 @@
 import type { LoaderFunctionArgs } from 'react-router-dom';
 import { loadFeedbackInsightsReportData } from 'src/routes/load/loadFeedbackInsightsReport';
+import type { FeedbackInsightScopeType } from 'lib/interfaces/domain/feedback.domain';
 
-export async function LoaderFeedbacksInsightsReport(_args: LoaderFunctionArgs) {
-  void _args;
-  return await loadFeedbackInsightsReportData();
+function parseScopeType(value: string | null): FeedbackInsightScopeType | undefined {
+  const normalized = String(value ?? '').trim().toUpperCase();
+
+  if (
+    normalized === 'COMPANY' ||
+    normalized === 'PRODUCT' ||
+    normalized === 'SERVICE' ||
+    normalized === 'DEPARTMENT'
+  ) {
+    return normalized;
+  }
+
+  return undefined;
+}
+
+export async function LoaderFeedbacksInsightsReport({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+
+  const scope_type = parseScopeType(url.searchParams.get('scope_type')) ?? 'COMPANY';
+  const catalog_item_id = String(url.searchParams.get('catalog_item_id') ?? '').trim() || undefined;
+
+  const data = await loadFeedbackInsightsReportData({
+    scope_type,
+    catalog_item_id,
+  });
+
+  return {
+    ...data,
+    filters: {
+      scope_type,
+      catalog_item_id: catalog_item_id ?? null,
+    },
+  };
 }

--- a/src/routes/loaders/loaderFeedbacksInsightsReport.ts
+++ b/src/routes/loaders/loaderFeedbacksInsightsReport.ts
@@ -23,16 +23,8 @@ export async function LoaderFeedbacksInsightsReport({ request }: LoaderFunctionA
   const scope_type = parseScopeType(url.searchParams.get('scope_type')) ?? 'COMPANY';
   const catalog_item_id = String(url.searchParams.get('catalog_item_id') ?? '').trim() || undefined;
 
-  const data = await loadFeedbackInsightsReportData({
+  return await loadFeedbackInsightsReportData({
     scope_type,
     catalog_item_id,
   });
-
-  return {
-    ...data,
-    filters: {
-      scope_type,
-      catalog_item_id: catalog_item_id ?? null,
-    },
-  };
 }

--- a/src/server/express/endpoints/protected/EndpointsEnterprise.ts
+++ b/src/server/express/endpoints/protected/EndpointsEnterprise.ts
@@ -239,13 +239,25 @@ async function getCompanyFeedbackQuestionsSnapshot(
     .eq('enterprise_id', enterpriseId)
     .eq('scope_type', 'COMPANY')
     .is('catalog_item_id', null)
-    .order('question_order', { ascending: true });
+    .order('question_order', { ascending: true })
+    .order('updated_at', { ascending: false })
+    .order('created_at', { ascending: false });
 
   if (error || !data) {
     return [];
   }
 
-  return data;
+  const firstByOrder = new Map<number, (typeof data)[number]>();
+
+  for (const item of data) {
+    if (!firstByOrder.has(item.question_order)) {
+      firstByOrder.set(item.question_order, item);
+    }
+  }
+
+  return Array.from(firstByOrder.values()).sort(
+    (left, right) => left.question_order - right.question_order,
+  );
 }
 
 async function syncCompanyFeedbackQuestions(params: {
@@ -261,40 +273,40 @@ async function syncCompanyFeedbackQuestions(params: {
     return { error: true as const };
   }
 
-  const existing = await getCompanyFeedbackQuestionsSnapshot(supabase, enterpriseId);
-  const existingByOrder = new Map(
-    existing.map((question) => [question.question_order, question]),
-  );
-
   for (const item of normalizedItems) {
-    const current = existingByOrder.get(item.question_order);
+    const { data: updatedRows, error: updateError } = await supabase
+      .from('questions_of_feedbacks')
+      .update({
+        question_text: item.question_text,
+        is_active: item.is_active,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('enterprise_id', enterpriseId)
+      .eq('scope_type', 'COMPANY')
+      .is('catalog_item_id', null)
+      .eq('question_order', item.question_order)
+      .select('id');
 
-    if (current?.id) {
-      const { error } = await supabase
-        .from('questions_of_feedbacks')
-        .update({
-          question_text: item.question_text,
-          is_active: item.is_active,
-          updated_at: new Date().toISOString(),
-        })
-        .eq('id', current.id);
+    if (updateError) {
+      return { error: true as const };
+    }
 
-      if (error) {
-        return { error: true as const };
-      }
+    if ((updatedRows?.length ?? 0) > 0) {
       continue;
     }
 
-    const { error } = await supabase.from('questions_of_feedbacks').insert({
-      enterprise_id: enterpriseId,
-      scope_type: 'COMPANY',
-      catalog_item_id: null,
-      question_order: item.question_order,
-      question_text: item.question_text,
-      is_active: item.is_active,
-    });
+    const { error: insertError } = await supabase
+      .from('questions_of_feedbacks')
+      .insert({
+        enterprise_id: enterpriseId,
+        scope_type: 'COMPANY',
+        catalog_item_id: null,
+        question_order: item.question_order,
+        question_text: item.question_text,
+        is_active: item.is_active,
+      });
 
-    if (error) {
+    if (insertError) {
       return { error: true as const };
     }
   }

--- a/src/server/express/endpoints/protected/EndpointsEnterprise.ts
+++ b/src/server/express/endpoints/protected/EndpointsEnterprise.ts
@@ -20,6 +20,12 @@ type CatalogItemInput = {
   status?: 'ACTIVE' | 'INACTIVE';
 };
 
+type CompanyFeedbackQuestionInput = {
+  question_order?: number;
+  question_text?: string;
+  is_active?: boolean;
+};
+
 type CollectingDataPayload = {
   company_objective?: string | null;
   analytics_goal?: string | null;
@@ -31,7 +37,24 @@ type CollectingDataPayload = {
   catalog_products?: CatalogItemInput[] | null;
   catalog_services?: CatalogItemInput[] | null;
   catalog_departments?: CatalogItemInput[] | null;
+  company_feedback_questions?: CompanyFeedbackQuestionInput[] | null;
 };
+
+const DEFAULT_COMPANY_FEEDBACK_QUESTIONS = [
+  {
+    question_order: 1,
+    question_text: 'Como foi sua experiência em relação ao atendimento?',
+  },
+  {
+    question_order: 2,
+    question_text: 'O que você achou da qualidade do produto/serviço?',
+  },
+  {
+    question_order: 3,
+    question_text:
+      'Como você avalia a relação entre o valor pago e a qualidade do produto/serviço?',
+  },
+];
 
 function normalizeCatalogItems(items: CatalogItemInput[] | null | undefined) {
   return (items ?? [])
@@ -183,6 +206,102 @@ async function getCatalogSnapshot(
   };
 }
 
+function normalizeCompanyFeedbackQuestions(
+  items: CompanyFeedbackQuestionInput[] | null | undefined,
+) {
+  const source = Array.isArray(items) && items.length > 0
+    ? items
+    : DEFAULT_COMPANY_FEEDBACK_QUESTIONS;
+
+  return source
+    .slice(0, 3)
+    .map((item, index) => ({
+      question_order: (index + 1) as 1 | 2 | 3,
+      question_text: String(item?.question_text ?? '').trim(),
+      is_active: item?.is_active === false ? false : true,
+    }))
+    .filter((item) => item.question_text.length > 0);
+}
+
+async function getCompanyFeedbackQuestionsSnapshot(
+  supabase: express.Request['supabase'],
+  enterpriseId: string,
+) {
+  if (!supabase) {
+    return [];
+  }
+
+  const { data, error } = await supabase
+    .from('questions_of_feedbacks')
+    .select(
+      'id, enterprise_id, scope_type, catalog_item_id, question_order, question_text, is_active, created_at, updated_at',
+    )
+    .eq('enterprise_id', enterpriseId)
+    .eq('scope_type', 'COMPANY')
+    .is('catalog_item_id', null)
+    .order('question_order', { ascending: true });
+
+  if (error || !data) {
+    return [];
+  }
+
+  return data;
+}
+
+async function syncCompanyFeedbackQuestions(params: {
+  supabase: express.Request['supabase'];
+  enterpriseId: string;
+  items: CompanyFeedbackQuestionInput[] | null | undefined;
+}) {
+  const { supabase, enterpriseId, items } = params;
+  if (!supabase) return { error: true as const };
+
+  const normalizedItems = normalizeCompanyFeedbackQuestions(items);
+  if (normalizedItems.length !== 3) {
+    return { error: true as const };
+  }
+
+  const existing = await getCompanyFeedbackQuestionsSnapshot(supabase, enterpriseId);
+  const existingByOrder = new Map(
+    existing.map((question) => [question.question_order, question]),
+  );
+
+  for (const item of normalizedItems) {
+    const current = existingByOrder.get(item.question_order);
+
+    if (current?.id) {
+      const { error } = await supabase
+        .from('questions_of_feedbacks')
+        .update({
+          question_text: item.question_text,
+          is_active: item.is_active,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', current.id);
+
+      if (error) {
+        return { error: true as const };
+      }
+      continue;
+    }
+
+    const { error } = await supabase.from('questions_of_feedbacks').insert({
+      enterprise_id: enterpriseId,
+      scope_type: 'COMPANY',
+      catalog_item_id: null,
+      question_order: item.question_order,
+      question_text: item.question_text,
+      is_active: item.is_active,
+    });
+
+    if (error) {
+      return { error: true as const };
+    }
+  }
+
+  return { error: false as const };
+}
+
 export function EndpointsEnterprise(app: express.Express) {
   // Busca os dados da empresa.
   app.get('/api/protected/user/enterprise', requireAuth, async (req, res) => {
@@ -296,8 +415,18 @@ export function EndpointsEnterprise(app: express.Express) {
       }
 
       const catalog = await getCatalogSnapshot(supabase, enterpriseRow.id);
+      const companyFeedbackQuestions = await getCompanyFeedbackQuestionsSnapshot(
+        supabase,
+        enterpriseRow.id,
+      );
 
-      return res.json({ collecting: { ...collecting, ...catalog } });
+      return res.json({
+        collecting: {
+          ...collecting,
+          ...catalog,
+          company_feedback_questions: companyFeedbackQuestions,
+        },
+      });
     },
   );
 
@@ -383,12 +512,17 @@ export function EndpointsEnterprise(app: express.Express) {
         payload,
         'catalog_departments',
       );
+      const hasCompanyFeedbackQuestions = Object.prototype.hasOwnProperty.call(
+        payload,
+        'company_feedback_questions',
+      );
 
       if (
         Object.keys(updateData).length === 1 &&
         !hasCatalogProducts &&
         !hasCatalogServices &&
-        !hasCatalogDepartments
+        !hasCatalogDepartments &&
+        !hasCompanyFeedbackQuestions
       ) {
         return sendTypedError(res, 400, API_ERROR_EMPTY_PAYLOAD);
       }
@@ -490,17 +624,36 @@ export function EndpointsEnterprise(app: express.Express) {
               })
             : { error: false as const };
 
+        const syncQuestionsResult = hasCompanyFeedbackQuestions
+          ? await syncCompanyFeedbackQuestions({
+              supabase,
+              enterpriseId: enterpriseRow.id,
+              items: payload.company_feedback_questions,
+            })
+          : { error: false as const };
+
         if (
           syncProductResult.error ||
           syncServiceResult.error ||
-          syncDepartmentResult.error
+          syncDepartmentResult.error ||
+          syncQuestionsResult.error
         ) {
           return sendTypedError(res, 400, API_ERROR_UPSERT_FAILED);
         }
 
         const catalog = await getCatalogSnapshot(supabase, enterpriseRow.id);
+        const companyFeedbackQuestions = await getCompanyFeedbackQuestionsSnapshot(
+          supabase,
+          enterpriseRow.id,
+        );
 
-        return res.json({ collecting: { ...data, ...catalog } });
+        return res.json({
+          collecting: {
+            ...data,
+            ...catalog,
+            company_feedback_questions: companyFeedbackQuestions,
+          },
+        });
       }
 
       const syncProductResult =
@@ -536,17 +689,36 @@ export function EndpointsEnterprise(app: express.Express) {
             })
           : { error: false as const };
 
+      const syncQuestionsResult = hasCompanyFeedbackQuestions
+        ? await syncCompanyFeedbackQuestions({
+            supabase,
+            enterpriseId: enterpriseRow.id,
+            items: payload.company_feedback_questions,
+          })
+        : { error: false as const };
+
       if (
         syncProductResult.error ||
         syncServiceResult.error ||
-        syncDepartmentResult.error
+        syncDepartmentResult.error ||
+        syncQuestionsResult.error
       ) {
         return sendTypedError(res, 400, API_ERROR_UPSERT_FAILED);
       }
 
       const catalog = await getCatalogSnapshot(supabase, enterpriseRow.id);
+      const companyFeedbackQuestions = await getCompanyFeedbackQuestionsSnapshot(
+        supabase,
+        enterpriseRow.id,
+      );
 
-      return res.json({ collecting: { ...updated, ...catalog } });
+      return res.json({
+        collecting: {
+          ...updated,
+          ...catalog,
+          company_feedback_questions: companyFeedbackQuestions,
+        },
+      });
     },
   );
 
@@ -621,17 +793,34 @@ export function EndpointsEnterprise(app: express.Express) {
         disableAll: payload.uses_company_departments === false,
       });
 
+      const syncQuestionsResult = await syncCompanyFeedbackQuestions({
+        supabase,
+        enterpriseId: enterpriseRow.id,
+        items: payload.company_feedback_questions,
+      });
+
       if (
         syncProductResult.error ||
         syncServiceResult.error ||
-        syncDepartmentResult.error
+        syncDepartmentResult.error ||
+        syncQuestionsResult.error
       ) {
         return sendTypedError(res, 400, API_ERROR_UPSERT_FAILED);
       }
 
       const catalog = await getCatalogSnapshot(supabase, enterpriseRow.id);
+      const companyFeedbackQuestions = await getCompanyFeedbackQuestionsSnapshot(
+        supabase,
+        enterpriseRow.id,
+      );
 
-      return res.json({ collecting: { ...data, ...catalog } });
+      return res.json({
+        collecting: {
+          ...data,
+          ...catalog,
+          company_feedback_questions: companyFeedbackQuestions,
+        },
+      });
     },
   );
 }

--- a/src/server/express/endpoints/protected/EndpointsFeedbacks.ts
+++ b/src/server/express/endpoints/protected/EndpointsFeedbacks.ts
@@ -590,7 +590,7 @@ export function EndpointsFeedbacks(app: express.Express) {
               filteredCollectionPointIds = (companyCollectionPoints ?? []).map((cp) => cp.id);
             }
           } else if (catalogItemId) {
-            let pointsQuery = supabase
+            const pointsQuery = supabase
               .from('collection_points')
               .select('id')
               .eq('enterprise_id', enterprise.id)

--- a/src/server/express/endpoints/protected/EndpointsFeedbacks.ts
+++ b/src/server/express/endpoints/protected/EndpointsFeedbacks.ts
@@ -21,6 +21,21 @@ type FeedbackQuestionAnswerRow = {
   created_at: string;
 };
 
+function parseInsightScopeType(rawValue: unknown) {
+  const normalized = String(rawValue ?? '').trim().toUpperCase();
+
+  if (
+    normalized === 'COMPANY' ||
+    normalized === 'PRODUCT' ||
+    normalized === 'SERVICE' ||
+    normalized === 'DEPARTMENT'
+  ) {
+    return normalized;
+  }
+
+  return undefined;
+}
+
 export function EndpointsFeedbacks(app: express.Express) {
   // Busca feedbacks da empresa com paginação
   app.get('/api/protected/user/feedbacks', requireAuth, async (req, res) => {
@@ -424,6 +439,8 @@ export function EndpointsFeedbacks(app: express.Express) {
     async (req, res) => {
       const supabase = req.supabase!;
       const user = req.user!;
+      const scopeType = parseInsightScopeType(req.query.scope_type) ?? 'COMPANY';
+      const catalogItemId = String(req.query.catalog_item_id ?? '').trim() || null;
 
       try {
         // Buscar a empresa do usuário
@@ -437,30 +454,85 @@ export function EndpointsFeedbacks(app: express.Express) {
           return sendTypedError(res, 404, API_ERROR_ENTERPRISE_NOT_FOUND);
         }
 
-        const { data: report, error } = await supabase
+        let scopedQuery = supabase
+          .from('feedback_insights_report')
+          .select(
+            'summary, recommendations, updated_at, scope_type, catalog_item_id',
+          )
+          .eq('enterprise_id', enterprise.id)
+          .eq('scope_type', scopeType)
+          .order('updated_at', { ascending: false })
+          .limit(1);
+
+        if (catalogItemId) {
+          scopedQuery = scopedQuery.eq('catalog_item_id', catalogItemId);
+        } else if (scopeType === 'COMPANY') {
+          scopedQuery = scopedQuery.is('catalog_item_id', null);
+        }
+
+        const { data: scopedRows, error: scopedError } = await scopedQuery;
+
+        if (!scopedError) {
+          const report = Array.isArray(scopedRows) ? scopedRows[0] : null;
+
+          if (!report) {
+            return res.json({
+              summary: null,
+              recommendations: [],
+              updatedAt: null,
+              scopeType,
+              catalogItemId,
+            });
+          }
+
+          return res.json({
+            summary: (report.summary as string | null) ?? null,
+            recommendations: ((report.recommendations ??
+              []) as string[]).filter((rec) => !!rec && rec.trim().length > 0),
+            updatedAt: (report.updated_at as string | null) ?? null,
+            scopeType: (report.scope_type as string | null) ?? scopeType,
+            catalogItemId: (report.catalog_item_id as string | null) ?? catalogItemId,
+          });
+        }
+
+        if (scopeType !== 'COMPANY' || catalogItemId) {
+          return res.json({
+            summary: null,
+            recommendations: [],
+            updatedAt: null,
+            scopeType,
+            catalogItemId,
+          });
+        }
+
+        const { data: legacyReport, error: legacyError } = await supabase
           .from('feedback_insights_report')
           .select('summary, recommendations, updated_at')
           .eq('enterprise_id', enterprise.id)
           .maybeSingle();
 
-        if (error) {
-          console.error('Erro ao buscar feedback_insights_report:', error);
+        if (legacyError) {
+          console.error('Erro ao buscar feedback_insights_report:', legacyError);
           return sendTypedError(res, 500, API_ERROR_FAILED_TO_FETCH_FEEDBACK_INSIGHTS_REPORT);
         }
 
-        if (!report) {
+        if (!legacyReport) {
           return res.json({
             summary: null,
             recommendations: [],
             updatedAt: null,
+            scopeType,
+            catalogItemId,
           });
         }
 
         return res.json({
-          summary: (report.summary as string | null) ?? null,
-          recommendations: ((report.recommendations ??
+          summary: (legacyReport.summary as string | null) ?? null,
+          recommendations: ((legacyReport.recommendations ??
             []) as string[]).filter((rec) => !!rec && rec.trim().length > 0),
-          updatedAt: (report.updated_at as string | null) ?? null,
+          updatedAt: (legacyReport.updated_at as string | null) ?? null,
+          scopeType,
+          catalogItemId,
         });
       } catch (error) {
         console.error('Erro ao buscar relatório de insights (IA):', error);
@@ -483,6 +555,8 @@ export function EndpointsFeedbacks(app: express.Express) {
         | 'neutral'
         | 'negative'
         | undefined) ?? undefined;
+      const scopeType = parseInsightScopeType(req.query.scope_type);
+      const catalogItemId = String(req.query.catalog_item_id ?? '').trim() || null;
 
       try {
         // Buscar a empresa do usuário
@@ -494,6 +568,106 @@ export function EndpointsFeedbacks(app: express.Express) {
 
         if (enterpriseError || !enterprise) {
           return sendTypedError(res, 404, API_ERROR_ENTERPRISE_NOT_FOUND);
+        }
+
+        let filteredCollectionPointIds: string[] | null = null;
+
+        if (scopeType || catalogItemId) {
+          if (scopeType === 'COMPANY') {
+            if (catalogItemId) {
+              filteredCollectionPointIds = [];
+            } else {
+              const { data: companyCollectionPoints, error: companyCpError } = await supabase
+                .from('collection_points')
+                .select('id')
+                .eq('enterprise_id', enterprise.id)
+                .is('catalog_item_id', null);
+
+              if (companyCpError) {
+                return sendTypedError(res, 500, API_ERROR_FAILED_TO_FETCH_FEEDBACK_ANALYSIS);
+              }
+
+              filteredCollectionPointIds = (companyCollectionPoints ?? []).map((cp) => cp.id);
+            }
+          } else if (catalogItemId) {
+            let pointsQuery = supabase
+              .from('collection_points')
+              .select('id')
+              .eq('enterprise_id', enterprise.id)
+              .eq('catalog_item_id', catalogItemId);
+
+            if (scopeType) {
+              const { data: catalogItem, error: catalogItemError } = await supabase
+                .from('catalog_items')
+                .select('id')
+                .eq('enterprise_id', enterprise.id)
+                .eq('id', catalogItemId)
+                .eq('kind', scopeType)
+                .maybeSingle();
+
+              if (catalogItemError) {
+                return sendTypedError(res, 500, API_ERROR_FAILED_TO_FETCH_FEEDBACK_ANALYSIS);
+              }
+
+              if (!catalogItem) {
+                filteredCollectionPointIds = [];
+              }
+            }
+
+            if (!filteredCollectionPointIds) {
+              const { data: points, error: pointsError } = await pointsQuery;
+
+              if (pointsError) {
+                return sendTypedError(res, 500, API_ERROR_FAILED_TO_FETCH_FEEDBACK_ANALYSIS);
+              }
+
+              filteredCollectionPointIds = (points ?? []).map((cp) => cp.id);
+            }
+          } else if (scopeType) {
+            const { data: catalogItems, error: catalogItemsError } = await supabase
+              .from('catalog_items')
+              .select('id')
+              .eq('enterprise_id', enterprise.id)
+              .eq('kind', scopeType);
+
+            if (catalogItemsError) {
+              return sendTypedError(res, 500, API_ERROR_FAILED_TO_FETCH_FEEDBACK_ANALYSIS);
+            }
+
+            const catalogIds = (catalogItems ?? []).map((item) => item.id);
+
+            if (catalogIds.length === 0) {
+              filteredCollectionPointIds = [];
+            } else {
+              const { data: points, error: pointsError } = await supabase
+                .from('collection_points')
+                .select('id')
+                .eq('enterprise_id', enterprise.id)
+                .in('catalog_item_id', catalogIds);
+
+              if (pointsError) {
+                return sendTypedError(res, 500, API_ERROR_FAILED_TO_FETCH_FEEDBACK_ANALYSIS);
+              }
+
+              filteredCollectionPointIds = (points ?? []).map((cp) => cp.id);
+            }
+          }
+        }
+
+        if (filteredCollectionPointIds && filteredCollectionPointIds.length === 0) {
+          return res.json({
+            items: [],
+            summary: {
+              totalAnalyzed: 0,
+              sentiments: {
+                positive: 0,
+                neutral: 0,
+                negative: 0,
+              },
+              topCategories: [],
+              topKeywords: [],
+            },
+          });
         }
 
         // Buscar feedbacks com análise associada
@@ -513,6 +687,10 @@ export function EndpointsFeedbacks(app: express.Express) {
           `,
           )
           .eq('enterprise_id', enterprise.id);
+
+        if (filteredCollectionPointIds) {
+          query = query.in('collection_point_id', filteredCollectionPointIds);
+        }
 
         if (sentimentFilter) {
           query = query.eq('feedback_analysis.sentiment', sentimentFilter);

--- a/src/server/express/endpoints/protected/EndpointsFeedbacks.ts
+++ b/src/server/express/endpoints/protected/EndpointsFeedbacks.ts
@@ -12,6 +12,15 @@ import {
 import { normalizeFeedbackAnalysisRows } from '../../../../../lib/utils/normalizeFeedbackAnalysisRows.js';
 import { sendTypedError } from '../../../../../lib/utils/sendTypedError.js';
 
+type FeedbackQuestionAnswerRow = {
+  feedback_id: string;
+  question_id: string;
+  question_text_snapshot: string;
+  answer_value: 'PESSIMO' | 'RUIM' | 'MEDIANA' | 'BOA' | 'OTIMA';
+  answer_score: number;
+  created_at: string;
+};
+
 export function EndpointsFeedbacks(app: express.Express) {
   // Busca feedbacks da empresa com paginação
   app.get('/api/protected/user/feedbacks', requireAuth, async (req, res) => {
@@ -279,8 +288,54 @@ export function EndpointsFeedbacks(app: express.Express) {
         };
       });
 
+      const feedbackIds = normalizedFeedbacks
+        .map((feedback) => feedback.id)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0);
+
+      const answersByFeedbackId = new Map<
+        string,
+        Array<{
+          question_id: string;
+          question_text_snapshot: string;
+          answer_value: 'PESSIMO' | 'RUIM' | 'MEDIANA' | 'BOA' | 'OTIMA';
+          answer_score: number;
+        }>
+      >();
+
+      if (feedbackIds.length > 0) {
+        const { data: answerRows, error: answersError } = await supabase
+          .from('feedback_question_answers')
+          .select(
+            'feedback_id, question_id, question_text_snapshot, answer_value, answer_score, created_at',
+          )
+          .in('feedback_id', feedbackIds)
+          .order('created_at', { ascending: true });
+
+        if (answersError) {
+          console.error('Erro ao buscar respostas dinâmicas dos feedbacks:', answersError);
+        } else {
+          (answerRows as FeedbackQuestionAnswerRow[] | null)?.forEach((row) => {
+            const current = answersByFeedbackId.get(row.feedback_id) ?? [];
+
+            current.push({
+              question_id: row.question_id,
+              question_text_snapshot: row.question_text_snapshot,
+              answer_value: row.answer_value,
+              answer_score: row.answer_score,
+            });
+
+            answersByFeedbackId.set(row.feedback_id, current);
+          });
+        }
+      }
+
+      const normalizedFeedbacksWithAnswers = normalizedFeedbacks.map((feedback) => ({
+        ...feedback,
+        feedback_question_answers: answersByFeedbackId.get(feedback.id) ?? [],
+      }));
+
       return res.json({
-        feedbacks: normalizedFeedbacks,
+        feedbacks: normalizedFeedbacksWithAnswers,
         pagination: {
           currentPage: page,
           totalPages,

--- a/src/server/express/endpoints/protected/EndpoitsIAStudio.ts
+++ b/src/server/express/endpoints/protected/EndpoitsIAStudio.ts
@@ -7,6 +7,21 @@ import {
 import { API_ERROR_INTERNAL_SERVER_ERROR } from '../../../../../lib/constants/server/errors.js';
 import { sendTypedError } from '../../../../../lib/utils/sendTypedError.js';
 
+function parseScopeType(value: unknown) {
+  const normalized = String(value ?? '').trim().toUpperCase();
+
+  if (
+    normalized === 'COMPANY' ||
+    normalized === 'PRODUCT' ||
+    normalized === 'SERVICE' ||
+    normalized === 'DEPARTMENT'
+  ) {
+    return normalized;
+  }
+
+  return undefined;
+}
+
 export function EndpointsIAStudio(app: express.Express) {
   app.post(
     '/api/protected/ia-studio/send-message',
@@ -20,11 +35,18 @@ export function EndpointsIAStudio(app: express.Express) {
           ? req.body.limit
           : undefined;
 
+      const scope_type = parseScopeType(req.body?.scope_type);
+      const catalog_item_id =
+        typeof req.body?.catalog_item_id === 'string' &&
+        req.body.catalog_item_id.trim().length > 0
+          ? req.body.catalog_item_id.trim()
+          : undefined;
+
       try {
         const result = await analyzeFeedbacksForEnterprise({
           supabase,
           userId: user.id,
-          options: { limit },
+          options: { limit, scope_type, catalog_item_id },
         });
 
         return res.json(result);

--- a/src/server/express/endpoints/public/EndpointsEnterprise.ts
+++ b/src/server/express/endpoints/public/EndpointsEnterprise.ts
@@ -70,6 +70,52 @@ export function EndpointsEnterprise(app: express.Express) {
         }
       }
 
+      const fetchQuestions = async (
+        scopeType: 'COMPANY' | 'PRODUCT' | 'SERVICE' | 'DEPARTMENT',
+        catalogItemContextId: string | null,
+      ) => {
+        let query = supabase
+          .from('questions_of_feedbacks')
+          .select('id, scope_type, catalog_item_id, question_order, question_text')
+          .eq('enterprise_id', enterprise.id)
+          .eq('scope_type', scopeType)
+          .eq('is_active', true)
+          .order('question_order', { ascending: true });
+
+        if (scopeType === 'COMPANY') {
+          query = query.is('catalog_item_id', null);
+        } else {
+          query = catalogItemContextId
+            ? query.eq('catalog_item_id', catalogItemContextId)
+            : query.is('catalog_item_id', null);
+        }
+
+        return await query;
+      };
+
+      const currentScope: 'COMPANY' | 'PRODUCT' | 'SERVICE' | 'DEPARTMENT' =
+        contextItemKind ?? 'COMPANY';
+
+      let { data: questions, error: questionsError } = await fetchQuestions(
+        currentScope,
+        contextCatalogItemId,
+      );
+
+      // Fallback para COMPANY quando QR de item ainda não tiver perguntas específicas.
+      if (
+        !questionsError &&
+        currentScope !== 'COMPANY' &&
+        (!questions || questions.length === 0)
+      ) {
+        const fallback = await fetchQuestions('COMPANY', null);
+        questions = fallback.data;
+        questionsError = fallback.error;
+      }
+
+      if (questionsError) {
+        console.error('Erro ao buscar perguntas públicas de feedback:', questionsError);
+      }
+
       return res.json({
         id: enterprise.id,
         name: enterprise.name || 'Empresa',
@@ -77,6 +123,7 @@ export function EndpointsEnterprise(app: express.Express) {
         catalog_item_id: contextCatalogItemId,
         item_name: contextItemName,
         item_kind: contextItemKind,
+        questions: questions ?? [],
       });
     } catch (err) {
       console.error('Erro ao buscar empresa:', err);

--- a/src/server/express/endpoints/public/EndpointsQRCode.ts
+++ b/src/server/express/endpoints/public/EndpointsQRCode.ts
@@ -15,6 +15,23 @@ import {
 } from '../../../../../lib/constants/server/errors.js';
 import { sendTypedError } from '../../../../../lib/utils/sendTypedError.js';
 
+function mapAnswerScore(answerValue: string): number {
+  switch (answerValue) {
+    case 'PESSIMO':
+      return 1;
+    case 'RUIM':
+      return 2;
+    case 'MEDIANA':
+      return 3;
+    case 'BOA':
+      return 4;
+    case 'OTIMA':
+      return 5;
+    default:
+      return 0;
+  }
+}
+
 export function EndpointsQRCode(app: express.Express) {
   // Recebe feedback público via QR Code
   app.post('/api/public/qrcode/feedback', async (req, res) => {
@@ -56,7 +73,7 @@ export function EndpointsQRCode(app: express.Express) {
     // 1. Buscar collection_point do tipo QR_CODE para a empresa (não criar no fluxo público)
     let cpQuery = supabase
       .from('collection_points')
-      .select('id, name, catalog_item_id')
+      .select('id, name, catalog_item_id, catalog_items(kind)')
       .eq('enterprise_id', payload.enterprise_id)
       .eq('type', 'QR_CODE')
       .eq('status', 'ACTIVE');
@@ -78,6 +95,69 @@ export function EndpointsQRCode(app: express.Express) {
 
     if (!collectionPoint) {
       return sendTypedError(res, 404, API_ERROR_COLLECTION_POINT_NOT_FOUND);
+    }
+
+    const cpCatalogItem = Array.isArray(collectionPoint.catalog_items)
+      ? collectionPoint.catalog_items[0]
+      : collectionPoint.catalog_items;
+
+    const contextScope: 'COMPANY' | 'PRODUCT' | 'SERVICE' | 'DEPARTMENT' =
+      cpCatalogItem?.kind === 'PRODUCT' ||
+      cpCatalogItem?.kind === 'SERVICE' ||
+      cpCatalogItem?.kind === 'DEPARTMENT'
+        ? cpCatalogItem.kind
+        : 'COMPANY';
+
+    const fetchQuestions = async (
+      scopeType: 'COMPANY' | 'PRODUCT' | 'SERVICE' | 'DEPARTMENT',
+      catalogItemId: string | null,
+    ) => {
+      let query = supabase
+        .from('questions_of_feedbacks')
+        .select('id, question_order, question_text')
+        .eq('enterprise_id', payload.enterprise_id)
+        .eq('scope_type', scopeType)
+        .eq('is_active', true)
+        .order('question_order', { ascending: true });
+
+      if (scopeType === 'COMPANY') {
+        query = query.is('catalog_item_id', null);
+      } else {
+        query = catalogItemId
+          ? query.eq('catalog_item_id', catalogItemId)
+          : query.is('catalog_item_id', null);
+      }
+
+      return await query;
+    };
+
+    let { data: currentQuestions, error: currentQuestionsError } =
+      await fetchQuestions(contextScope, collectionPoint.catalog_item_id ?? null);
+
+    if (
+      !currentQuestionsError &&
+      contextScope !== 'COMPANY' &&
+      (!currentQuestions || currentQuestions.length === 0)
+    ) {
+      const fallback = await fetchQuestions('COMPANY', null);
+      currentQuestions = fallback.data;
+      currentQuestionsError = fallback.error;
+    }
+
+    if (currentQuestionsError || !currentQuestions || currentQuestions.length !== 3) {
+      console.error('Perguntas não configuradas para o contexto do feedback:', currentQuestionsError);
+      return sendTypedError(res, 400, API_ERROR_INVALID_PAYLOAD);
+    }
+
+    const allowedQuestionIds = new Set(currentQuestions.map((question) => question.id));
+    const payloadQuestionIds = payload.answers.map((answer) => answer.question_id);
+
+    if (
+      payload.answers.length !== 3 ||
+      new Set(payloadQuestionIds).size !== 3 ||
+      payloadQuestionIds.some((questionId) => !allowedQuestionIds.has(questionId))
+    ) {
+      return sendTypedError(res, 400, API_ERROR_INVALID_PAYLOAD);
     }
 
     // 2. Buscar ou criar dispositivo rastreado PRIMEIRO
@@ -218,9 +298,12 @@ export function EndpointsQRCode(app: express.Express) {
     }
 
     // 3. Inserir feedback na tabela COM tracked_device_id (sem RETURNING para evitar RLS no SELECT)
+    const feedbackId = crypto.randomUUID();
+
     const { error: feedbackErr } = await supabase
       .from('feedback')
       .insert({
+        id: feedbackId,
         enterprise_id: payload.enterprise_id,
         collection_point_id: collectionPoint.id,
         tracked_device_id: trackedDevice!.id, // RELAÇÃO CORRETA!
@@ -230,6 +313,42 @@ export function EndpointsQRCode(app: express.Express) {
 
     if (feedbackErr) {
       console.error('Erro ao inserir feedback:', feedbackErr);
+      return sendTypedError(res, 500, API_ERROR_FEEDBACK_INSERT_FAILED);
+    }
+
+    const questionById = new Map(
+      currentQuestions.map((question) => [question.id, question]),
+    );
+
+    const answerRows = payload.answers.map((answer) => {
+      const question = questionById.get(answer.question_id);
+      const answerScore = mapAnswerScore(answer.answer_value);
+
+      return {
+        feedback_id: feedbackId,
+        question_id: answer.question_id,
+        question_text_snapshot: question?.question_text ?? '',
+        answer_value: answer.answer_value,
+        answer_score: answerScore,
+      };
+    });
+
+    if (answerRows.some((answerRow) => answerRow.answer_score === 0)) {
+      return sendTypedError(res, 400, API_ERROR_INVALID_PAYLOAD);
+    }
+
+    const { error: answersError } = await supabase
+      .from('feedback_question_answers')
+      .insert(answerRows);
+
+    if (answersError) {
+      console.error('Erro ao inserir respostas do feedback:', answersError);
+
+      await supabase
+        .from('feedback')
+        .delete()
+        .eq('id', feedbackId);
+
       return sendTypedError(res, 500, API_ERROR_FEEDBACK_INSERT_FAILED);
     }
 

--- a/src/server/express/services/iaStudioPromptBuilders.ts
+++ b/src/server/express/services/iaStudioPromptBuilders.ts
@@ -57,22 +57,22 @@ function getScopeInstructions(scopeType: FeedbackScopeType) {
     COMPANY: [
       'Contexto: feedbacks gerais da empresa (visão ampla da experiência).',
       'Priorize categorias como atendimento, comunicação, preço, ambiente, experiência geral e confiança.',
-      'Considere as respostas dinâmicas para qualificar pontos fortes e fracos de forma objetiva.',
+      'Considere respostas dinâmicas apenas como sinal auxiliar de polaridade, sem copiar rótulos para categorias/keywords.',
     ],
     PRODUCT: [
       'Contexto: feedbacks de produto específico.',
       'Priorize categorias como qualidade, durabilidade, custo-benefício, funcionalidades e embalagem.',
-      'Use o nome/descrição do produto e respostas dinâmicas para recomendações mais acionáveis de produto.',
+      'Use o nome/descrição do produto e respostas dinâmicas apenas para enriquecer contexto da análise textual.',
     ],
     SERVICE: [
       'Contexto: feedbacks de serviço específico.',
       'Priorize categorias como tempo de resposta, eficiência, cordialidade, clareza e resolução de problemas.',
-      'Considere respostas dinâmicas para detectar gargalos operacionais e oportunidades de melhoria do serviço.',
+      'Considere respostas dinâmicas apenas para apoiar inferências do texto, sem virar palavras-chave literais.',
     ],
     DEPARTMENT: [
       'Contexto: feedbacks de departamento/setor específico.',
       'Priorize categorias como processo interno, comunicação da equipe, agilidade e qualidade da interação.',
-      'Use respostas dinâmicas para orientar recomendações práticas para o time responsável.',
+      'Use respostas dinâmicas para apoiar recomendações práticas, mas extraia termos prioritariamente da descrição.',
     ],
   };
 
@@ -99,7 +99,12 @@ Regras IMPORTANTES:
 - Responda SEMPRE em JSON válido.
 - Não inclua comentários, texto fora do JSON ou explicações adicionais.
 - Use apenas os valores 'positive', 'neutral' ou 'negative' em "sentiment".
-- Em "categories" e "keywords", use arrays de strings curtas (ex.: ["atendimento", "preço"]).`;
+- Em "categories" e "keywords", use arrays de strings curtas (ex.: ["atendimento", "preço"]).
+- A fonte principal para categories/keywords é EXCLUSIVAMENTE o campo "message" do feedback.
+- Campos estruturados (rating, dynamic_answers, catalog_item) são contexto auxiliar e NÃO podem ser copiados literalmente.
+- NÃO use termos como "pessimo", "ruim", "mediana", "boa" ou "otima" como keywords/categorias.
+- NÃO copie texto das perguntas dinâmicas como keywords/categorias.
+- Se o texto for curto, prefira poucos termos relevantes e evidentes no próprio message.`;
 
   const scopeInstructions = getScopeInstructions(scopeType);
 
@@ -128,7 +133,18 @@ Regras IMPORTANTES:
   const payload = {
     analysis_scope: scopeType,
     enterprise: enterpriseContext,
-    feedbacks,
+    feedbacks: feedbacks.map((feedback) => ({
+      id: feedback.id,
+      created_at: feedback.created_at,
+      scope_type: feedback.scope_type,
+      message_primary: feedback.message,
+      context_signals: {
+        rating: feedback.rating,
+        dynamic_answers: feedback.dynamic_answers,
+        collection_point: feedback.collection_point,
+        catalog_item: feedback.catalog_item,
+      },
+    })),
   };
 
   return [

--- a/src/server/express/services/iaStudioPromptBuilders.ts
+++ b/src/server/express/services/iaStudioPromptBuilders.ts
@@ -1,0 +1,146 @@
+export type FeedbackScopeType =
+  | 'COMPANY'
+  | 'PRODUCT'
+  | 'SERVICE'
+  | 'DEPARTMENT';
+
+export type PromptFeedbackDynamicAnswer = {
+  question_id: string;
+  question_text_snapshot: string;
+  answer_value: 'PESSIMO' | 'RUIM' | 'MEDIANA' | 'BOA' | 'OTIMA';
+  answer_score: number;
+};
+
+export type PromptFeedbackInput = {
+  id: string;
+  message: string;
+  rating: number | null;
+  created_at: string | null;
+  scope_type: FeedbackScopeType;
+  collection_point: {
+    id: string | null;
+    name: string | null;
+    type: string | null;
+    identifier: string | null;
+  } | null;
+  catalog_item: {
+    id: string;
+    name: string;
+    kind: 'PRODUCT' | 'SERVICE' | 'DEPARTMENT';
+    description: string | null;
+  } | null;
+  dynamic_answers: PromptFeedbackDynamicAnswer[];
+};
+
+export type PromptEnterpriseContext = {
+  enterprise_name: string | null;
+  company_objective: string | null;
+  analytics_goal: string | null;
+  business_summary: string | null;
+  main_products_or_services: string[] | null;
+};
+
+export type PromptExpectedFeedbackItem = {
+  feedback_id: string;
+  sentiment: 'positive' | 'neutral' | 'negative';
+  categories: string[];
+  keywords: string[];
+};
+
+export type PromptExpectedGlobalInsights = {
+  summary?: string;
+  recommendations?: string[];
+};
+
+function getScopeInstructions(scopeType: FeedbackScopeType) {
+  const instructionsByScope: Record<FeedbackScopeType, string[]> = {
+    COMPANY: [
+      'Contexto: feedbacks gerais da empresa (visão ampla da experiência).',
+      'Priorize categorias como atendimento, comunicação, preço, ambiente, experiência geral e confiança.',
+      'Considere as respostas dinâmicas para qualificar pontos fortes e fracos de forma objetiva.',
+    ],
+    PRODUCT: [
+      'Contexto: feedbacks de produto específico.',
+      'Priorize categorias como qualidade, durabilidade, custo-benefício, funcionalidades e embalagem.',
+      'Use o nome/descrição do produto e respostas dinâmicas para recomendações mais acionáveis de produto.',
+    ],
+    SERVICE: [
+      'Contexto: feedbacks de serviço específico.',
+      'Priorize categorias como tempo de resposta, eficiência, cordialidade, clareza e resolução de problemas.',
+      'Considere respostas dinâmicas para detectar gargalos operacionais e oportunidades de melhoria do serviço.',
+    ],
+    DEPARTMENT: [
+      'Contexto: feedbacks de departamento/setor específico.',
+      'Priorize categorias como processo interno, comunicação da equipe, agilidade e qualidade da interação.',
+      'Use respostas dinâmicas para orientar recomendações práticas para o time responsável.',
+    ],
+  };
+
+  return instructionsByScope[scopeType];
+}
+
+export function buildIaPromptByScope(params: {
+  scopeType: FeedbackScopeType;
+  enterpriseContext: PromptEnterpriseContext;
+  feedbacks: PromptFeedbackInput[];
+}): string {
+  const { scopeType, enterpriseContext, feedbacks } = params;
+
+  const header = `Você é uma IA especialista em análise de feedbacks de clientes para empresas.
+Seu objetivo é:
+- Entender o contexto e os objetivos da empresa.
+- Analisar cada feedback individualmente.
+- Classificar o sentimento de cada feedback (positive, neutral, negative).
+- Categorizar o tema principal do feedback em poucas categorias de negócio.
+- Extrair palavras-chave importantes do texto.
+- Gerar insights acionáveis para ajudar a empresa a melhorar.
+
+Regras IMPORTANTES:
+- Responda SEMPRE em JSON válido.
+- Não inclua comentários, texto fora do JSON ou explicações adicionais.
+- Use apenas os valores 'positive', 'neutral' ou 'negative' em "sentiment".
+- Em "categories" e "keywords", use arrays de strings curtas (ex.: ["atendimento", "preço"]).`;
+
+  const scopeInstructions = getScopeInstructions(scopeType);
+
+  const expectedSchemaExample: {
+    feedbacks: PromptExpectedFeedbackItem[];
+    global_insights: PromptExpectedGlobalInsights;
+  } = {
+    feedbacks: [
+      {
+        feedback_id: 'uuid-do-feedback',
+        sentiment: 'positive',
+        categories: ['atendimento', 'experiência'],
+        keywords: ['agilidade', 'cordialidade'],
+      },
+    ],
+    global_insights: {
+      summary:
+        'Resumo geral dos principais padrões encontrados nos feedbacks, em poucas frases.',
+      recommendations: [
+        'Sugestão objetiva 1 para melhorar a experiência.',
+        'Sugestão objetiva 2 para melhorar processos, produto ou atendimento.',
+      ],
+    },
+  };
+
+  const payload = {
+    analysis_scope: scopeType,
+    enterprise: enterpriseContext,
+    feedbacks,
+  };
+
+  return [
+    header,
+    '',
+    `Escopo atual da análise: ${scopeType}`,
+    ...scopeInstructions.map((line) => `- ${line}`),
+    '',
+    'Estrutura exata de resposta (NÃO altere as chaves):',
+    JSON.stringify(expectedSchemaExample, null, 2),
+    '',
+    'Dados de entrada (em JSON):',
+    JSON.stringify(payload),
+  ].join('\n');
+}

--- a/src/server/express/services/iaStudioService.ts
+++ b/src/server/express/services/iaStudioService.ts
@@ -35,7 +35,16 @@ export type IaStudioResult = {
     keywords: string[];
   }[];
   globalInsights: IaGlobalInsights | null;
+  contexts: Array<{
+    scope_type: FeedbackScopeType;
+    catalog_item_id: string | null;
+    catalog_item_name: string | null;
+    analyzedCount: number;
+    globalInsights: IaGlobalInsights | null;
+  }>;
 };
+
+type IaStudioResultContext = IaStudioResult['contexts'][number];
 
 export type IaStudioOptions = {
   /**
@@ -43,6 +52,15 @@ export type IaStudioOptions = {
    * Default: 50, Máximo: 100.
    */
   limit?: number;
+  scope_type?: FeedbackScopeType;
+  catalog_item_id?: string;
+};
+
+type AnalysisBatch = {
+  scopeType: FeedbackScopeType;
+  catalogItemId: string | null;
+  catalogItemName: string | null;
+  feedbacks: FeedbackForAnalysis[];
 };
 
 type CollectingDataContext = {
@@ -167,78 +185,121 @@ function buildEnterpriseContext(params: {
   };
 }
 
-function groupFeedbacksByScope(feedbacks: FeedbackForAnalysis[]) {
-  const buckets = new Map<FeedbackScopeType, FeedbackForAnalysis[]>([
-    ['COMPANY', []],
-    ['PRODUCT', []],
-    ['SERVICE', []],
-    ['DEPARTMENT', []],
-  ]);
+function applyExecutionFilter(
+  feedbacks: FeedbackForAnalysis[],
+  options?: IaStudioOptions,
+) {
+  const scope = options?.scope_type;
+  const catalogItemId = options?.catalog_item_id?.trim();
 
-  for (const feedback of feedbacks) {
-    const scope = normalizeScopeType(feedback.scope_type);
-    buckets.get(scope)?.push(feedback);
+  if (!scope && !catalogItemId) {
+    return feedbacks;
   }
 
-  return Array.from(buckets.entries()).filter(([, items]) => items.length > 0);
+  return feedbacks.filter((feedback) => {
+    const feedbackScope = normalizeScopeType(feedback.scope_type);
+    const feedbackCatalogItemId = feedback.catalog_item?.id ?? null;
+
+    if (scope === 'COMPANY') {
+      return feedbackScope === 'COMPANY';
+    }
+
+    if (scope && feedbackScope !== scope) {
+      return false;
+    }
+
+    if (catalogItemId) {
+      return feedbackCatalogItemId === catalogItemId;
+    }
+
+    if (scope) {
+      return feedbackScope === scope;
+    }
+
+    return feedbackCatalogItemId !== null;
+  });
 }
 
-function mergeGlobalInsights(
-  items: Array<{
-    scopeType: FeedbackScopeType;
-    insights: IaGlobalInsights | null;
-  }>,
-): IaGlobalInsights | null {
-  const valid = items.filter((entry) => {
-    const summary = entry.insights?.summary?.trim();
-    const recommendations = (entry.insights?.recommendations ?? []).filter(
-      (value) => String(value).trim().length > 0,
-    );
+function buildAnalysisBatches(
+  feedbacks: FeedbackForAnalysis[],
+  options?: IaStudioOptions,
+): AnalysisBatch[] {
+  const scope = options?.scope_type;
+  const catalogItemId = options?.catalog_item_id?.trim();
 
-    return Boolean(summary) || recommendations.length > 0;
+  const companyFeedbacks = feedbacks.filter((feedback) =>
+    normalizeScopeType(feedback.scope_type) === 'COMPANY',
+  );
+
+  const itemBuckets = new Map<string, AnalysisBatch>();
+
+  feedbacks.forEach((feedback) => {
+    const feedbackScope = normalizeScopeType(feedback.scope_type);
+    const item = feedback.catalog_item;
+
+    if (feedbackScope === 'COMPANY' || !item?.id) {
+      return;
+    }
+
+    const key = `${feedbackScope}:${item.id}`;
+    const current = itemBuckets.get(key);
+
+    if (!current) {
+      itemBuckets.set(key, {
+        scopeType: feedbackScope,
+        catalogItemId: item.id,
+        catalogItemName: item.name,
+        feedbacks: [feedback],
+      });
+      return;
+    }
+
+    current.feedbacks.push(feedback);
   });
 
-  if (valid.length === 0) {
-    return null;
+  const itemBatches = Array.from(itemBuckets.values());
+
+  if (scope === 'COMPANY') {
+    return companyFeedbacks.length > 0
+      ? [
+          {
+            scopeType: 'COMPANY',
+            catalogItemId: null,
+            catalogItemName: null,
+            feedbacks: companyFeedbacks,
+          },
+        ]
+      : [];
   }
 
-  if (valid.length === 1) {
-    const single = valid[0].insights!;
-    return {
-      summary: single.summary,
-      recommendations: single.recommendations,
-    };
+  if (scope) {
+    const filteredByScope = itemBatches.filter((batch) => batch.scopeType === scope);
+
+    if (catalogItemId) {
+      return filteredByScope.filter((batch) => batch.catalogItemId === catalogItemId);
+    }
+
+    return filteredByScope;
   }
 
-  const summaryParts = valid
-    .map((entry) => {
-      const summary = entry.insights?.summary?.trim();
-      if (!summary) return null;
-      return `[${entry.scopeType}] ${summary}`;
-    })
-    .filter((part): part is string => Boolean(part));
+  if (catalogItemId) {
+    return itemBatches.filter((batch) => batch.catalogItemId === catalogItemId);
+  }
 
-  const recommendationSet = new Set<string>();
+  const batches: AnalysisBatch[] = [];
 
-  valid.forEach((entry) => {
-    (entry.insights?.recommendations ?? []).forEach((recommendation) => {
-      const text = String(recommendation ?? '').trim();
-      if (!text) return;
-      recommendationSet.add(text);
+  if (companyFeedbacks.length > 0) {
+    batches.push({
+      scopeType: 'COMPANY',
+      catalogItemId: null,
+      catalogItemName: null,
+      feedbacks: companyFeedbacks,
     });
-  });
-
-  const recommendations = Array.from(recommendationSet);
-  const summary = summaryParts.length > 0 ? summaryParts.join('\n\n') : undefined;
-
-  if (!summary && recommendations.length === 0) {
-    return null;
   }
 
-  return {
-    ...(summary ? { summary } : {}),
-    ...(recommendations.length > 0 ? { recommendations } : {}),
-  };
+  batches.push(...itemBatches);
+
+  return batches;
 }
 
 async function fetchFeedbacksForAnalysis(params: {
@@ -479,11 +540,14 @@ export async function analyzeFeedbacksForEnterprise(params: {
     limit,
   });
 
-  if (feedbacksForAnalysis.length === 0) {
+  const feedbacksForExecution = applyExecutionFilter(feedbacksForAnalysis, options);
+
+  if (feedbacksForExecution.length === 0) {
     return {
       analyzedCount: 0,
       feedbacksAnalyzed: [],
       globalInsights: null,
+      contexts: [],
     };
   }
 
@@ -493,7 +557,7 @@ export async function analyzeFeedbacksForEnterprise(params: {
     .select('feedback_id')
     .in(
       'feedback_id',
-      feedbacksForAnalysis.map((f) => f.id),
+      feedbacksForExecution.map((f) => f.id),
     );
 
   if (existingAnalysisError) {
@@ -508,7 +572,7 @@ export async function analyzeFeedbacksForEnterprise(params: {
     (existingAnalysis ?? []).map((row) => row.feedback_id as string),
   );
 
-  const feedbacksToAnalyze = feedbacksForAnalysis.filter(
+  const feedbacksToAnalyze = feedbacksForExecution.filter(
     (f) => !alreadyAnalyzedIds.has(f.id),
   );
 
@@ -517,6 +581,7 @@ export async function analyzeFeedbacksForEnterprise(params: {
       analyzedCount: 0,
       feedbacksAnalyzed: [],
       globalInsights: null,
+      contexts: [],
     };
   }
 
@@ -525,7 +590,16 @@ export async function analyzeFeedbacksForEnterprise(params: {
     collecting: collecting as CollectingDataContext | null,
   });
 
-  const feedbackGroupsByScope = groupFeedbacksByScope(feedbacksToAnalyze);
+  const analysisBatches = buildAnalysisBatches(feedbacksToAnalyze, options);
+
+  if (analysisBatches.length === 0) {
+    return {
+      analyzedCount: 0,
+      feedbacksAnalyzed: [],
+      globalInsights: null,
+      contexts: [],
+    };
+  }
 
   const apiKey = process.env.GEMINI_API_KEY;
   if (!apiKey) {
@@ -551,16 +625,13 @@ export async function analyzeFeedbacksForEnterprise(params: {
     }
   >();
 
-  const insightsByScope: Array<{
-    scopeType: FeedbackScopeType;
-    insights: IaGlobalInsights | null;
-  }> = [];
+  const insightsContexts: IaStudioResultContext[] = [];
 
-  for (const [scopeType, feedbackItems] of feedbackGroupsByScope) {
+  for (const batch of analysisBatches) {
     const prompt = buildIaPromptByScope({
-      scopeType,
+      scopeType: batch.scopeType,
       enterpriseContext,
-      feedbacks: feedbackItems,
+      feedbacks: batch.feedbacks,
     });
 
     const aiResponse = await ai.models.generateContent({
@@ -597,13 +668,16 @@ export async function analyzeFeedbacksForEnterprise(params: {
       );
     }
 
-    insightsByScope.push({
-      scopeType,
-      insights: parsed?.global_insights ?? null,
+    insightsContexts.push({
+      scope_type: batch.scopeType,
+      catalog_item_id: batch.catalogItemId,
+      catalog_item_name: batch.catalogItemName,
+      globalInsights: parsed?.global_insights ?? null,
+      analyzedCount: batch.feedbacks.length,
     });
 
     const items = Array.isArray(parsed?.feedbacks) ? parsed.feedbacks : [];
-    const allowedFeedbackIds = new Set(feedbackItems.map((item) => item.id));
+    const allowedFeedbackIds = new Set(batch.feedbacks.map((item) => item.id));
 
     items.forEach((item) => {
       if (
@@ -629,13 +703,20 @@ export async function analyzeFeedbacksForEnterprise(params: {
 
   const rowsToInsert = Array.from(rowsByFeedbackId.values());
 
-  const globalInsights = mergeGlobalInsights(insightsByScope);
+  const globalInsights =
+    insightsContexts.find(
+      (context) =>
+        context.scope_type === 'COMPANY' &&
+        context.catalog_item_id === null &&
+        context.globalInsights,
+    )?.globalInsights ?? insightsContexts[0]?.globalInsights ?? null;
 
   if (rowsToInsert.length === 0) {
     return {
       analyzedCount: 0,
       feedbacksAnalyzed: [],
       globalInsights,
+      contexts: insightsContexts,
     };
   }
 
@@ -652,29 +733,59 @@ export async function analyzeFeedbacksForEnterprise(params: {
     );
   }
 
-  // 7) Persistir relatório global de insights (summary + recommendations) por empresa
-  if (globalInsights) {
-    const summary = globalInsights.summary ?? null;
+  for (const context of insightsContexts) {
+    const summary = context.globalInsights?.summary?.trim() || null;
     const recommendations =
-      globalInsights.recommendations && globalInsights.recommendations.length > 0
-        ? globalInsights.recommendations
-        : null;
+      context.globalInsights?.recommendations?.filter((value: string) =>
+        String(value ?? '').trim(),
+      ) ?? [];
 
-    try {
-      await supabase
-        .from('feedback_insights_report')
-        .upsert(
-          {
-            enterprise_id: enterpriseId,
-            summary,
-            recommendations,
-            updated_at: new Date().toISOString(),
-          },
-          { onConflict: 'enterprise_id' },
-        );
-    } catch {
-      // Não deve quebrar o fluxo principal se o relatório falhar
-      console.error('Falha ao salvar feedback_insights_report');
+    const hasMeaningfulData = summary || recommendations.length > 0;
+
+    if (!hasMeaningfulData) {
+      continue;
+    }
+
+    const payload = {
+      enterprise_id: enterpriseId,
+      scope_type: context.scope_type,
+      catalog_item_id: context.catalog_item_id,
+      catalog_item_name: context.catalog_item_name,
+      summary,
+      recommendations,
+      updated_at: new Date().toISOString(),
+    };
+
+    const { error: scopedUpsertError } = await supabase
+      .from('feedback_insights_report')
+      .upsert(payload, {
+        onConflict: 'enterprise_id,scope_type,catalog_item_id',
+      });
+
+    if (!scopedUpsertError) {
+      continue;
+    }
+
+    if (context.scope_type !== 'COMPANY' || context.catalog_item_id !== null) {
+      console.error('Falha ao salvar feedback_insights_report segmentado', scopedUpsertError);
+      continue;
+    }
+
+    const legacyPayload = {
+      enterprise_id: enterpriseId,
+      summary,
+      recommendations,
+      updated_at: new Date().toISOString(),
+    };
+
+    const { error: legacyUpsertError } = await supabase
+      .from('feedback_insights_report')
+      .upsert(legacyPayload, {
+        onConflict: 'enterprise_id',
+      });
+
+    if (legacyUpsertError) {
+      console.error('Falha ao salvar feedback_insights_report legado', legacyUpsertError);
     }
   }
 
@@ -689,6 +800,7 @@ export async function analyzeFeedbacksForEnterprise(params: {
         keywords: (row.keywords ?? []) as string[],
       })) ?? [],
     globalInsights,
+    contexts: insightsContexts,
   };
 }
 

--- a/src/server/express/services/iaStudioService.ts
+++ b/src/server/express/services/iaStudioService.ts
@@ -187,6 +187,20 @@ function buildEnterpriseContext(params: {
   };
 }
 
+function hasRequiredEnterpriseInfoForAnalysis(
+  collecting: CollectingDataContext | null,
+) {
+  if (!collecting) {
+    return false;
+  }
+
+  const hasCompanyObjective = String(collecting.company_objective ?? '').trim().length > 0;
+  const hasAnalyticsGoal = String(collecting.analytics_goal ?? '').trim().length > 0;
+  const hasBusinessSummary = String(collecting.business_summary ?? '').trim().length > 0;
+
+  return hasCompanyObjective && hasAnalyticsGoal && hasBusinessSummary;
+}
+
 const STRUCTURED_ANSWER_LABELS = new Set<string>([
   'pessimo',
   'ruim',
@@ -684,6 +698,14 @@ export async function analyzeFeedbacksForEnterprise(params: {
       'Failed to fetch collecting data',
       500,
       'failed_to_fetch_collecting_data',
+    );
+  }
+
+  if (!hasRequiredEnterpriseInfoForAnalysis(collecting as CollectingDataContext | null)) {
+    throw new IaStudioServiceError(
+      'collecting_data_required_for_analysis',
+      422,
+      'collecting_data_required_for_analysis',
     );
   }
 

--- a/src/server/express/services/iaStudioService.ts
+++ b/src/server/express/services/iaStudioService.ts
@@ -1,16 +1,17 @@
 import { GoogleGenAI } from '@google/genai';
 import { createSupabaseServerClient } from '../supabase.js';
+import {
+  buildIaPromptByScope,
+  type FeedbackScopeType,
+  type PromptEnterpriseContext,
+  type PromptFeedbackInput,
+} from './iaStudioPromptBuilders.js';
 
 export type SupabaseServerClient = ReturnType<typeof createSupabaseServerClient>;
 
 export type Sentiment = 'positive' | 'negative' | 'neutral';
 
-export type FeedbackForAnalysis = {
-  id: string;
-  message: string;
-  rating: number | null;
-  created_at: string | null;
-};
+export type FeedbackForAnalysis = PromptFeedbackInput;
 
 export type IaFeedbackAnalysisItem = {
   feedback_id: string;
@@ -44,13 +45,64 @@ export type IaStudioOptions = {
   limit?: number;
 };
 
+type CollectingDataContext = {
+  company_objective?: string | null;
+  analytics_goal?: string | null;
+  business_summary?: string | null;
+  main_products_or_services?: string[] | null;
+};
+
+type RawFeedbackRow = {
+  id: string;
+  message: string;
+  rating: number | null;
+  created_at: string | null;
+  collection_points:
+    | {
+        id?: string | null;
+        name?: string | null;
+        type?: string | null;
+        identifier?: string | null;
+        catalog_item_id?: string | null;
+      }
+    | Array<{
+        id?: string | null;
+        name?: string | null;
+        type?: string | null;
+        identifier?: string | null;
+        catalog_item_id?: string | null;
+      }>
+    | null;
+};
+
+type RawCatalogItemRow = {
+  id: string;
+  name: string;
+  kind: string;
+  description: string | null;
+};
+
+type RawFeedbackQuestionAnswerRow = {
+  feedback_id: string;
+  question_id: string;
+  question_text_snapshot: string;
+  answer_value: 'PESSIMO' | 'RUIM' | 'MEDIANA' | 'BOA' | 'OTIMA';
+  answer_score: number;
+};
+
 export class IaStudioServiceError extends Error {
+  public statusCode: number;
+
+  public code: string;
+
   constructor(
     message: string,
-    public statusCode: number,
-    public code: string,
+    statusCode: number,
+    code: string,
   ) {
     super(message);
+    this.statusCode = statusCode;
+    this.code = code;
   }
 }
 
@@ -81,82 +133,291 @@ function extractJsonFromText(raw: string): string {
   return text;
 }
 
-function buildIaPrompt(params: {
+function normalizeScopeType(kind: string | null | undefined): FeedbackScopeType {
+  const normalized = String(kind ?? '').toUpperCase();
+
+  if (normalized === 'PRODUCT') return 'PRODUCT';
+  if (normalized === 'SERVICE') return 'SERVICE';
+  if (normalized === 'DEPARTMENT') return 'DEPARTMENT';
+  return 'COMPANY';
+}
+
+function resolveCollectionPoint(
+  collectionPointRaw: RawFeedbackRow['collection_points'],
+) {
+  if (Array.isArray(collectionPointRaw)) {
+    return collectionPointRaw[0] ?? null;
+  }
+
+  return collectionPointRaw ?? null;
+}
+
+function buildEnterpriseContext(params: {
   enterpriseName: string | null;
-  companyObjective: string | null;
-  analyticsGoal: string | null;
-  businessSummary: string | null;
-  mainProductsOrServices: string[] | null;
-  feedbacks: FeedbackForAnalysis[];
-}): string {
-  const {
-    enterpriseName,
-    companyObjective,
-    analyticsGoal,
-    businessSummary,
-    mainProductsOrServices,
-    feedbacks,
-  } = params;
+  collecting: CollectingDataContext | null;
+}): PromptEnterpriseContext {
+  const { enterpriseName, collecting } = params;
 
-  const header = `Você é uma IA especialista em análise de feedbacks de clientes para empresas.
-Seu objetivo é:
-- Entender o contexto e os objetivos da empresa.
-- Analisar cada feedback individualmente.
-- Classificar o sentimento de cada feedback (positive, neutral, negative).
-- Categorizar o tema principal do feedback em poucas categorias de negócio.
-- Extrair palavras-chave importantes do texto.
-- Gerar insights acionáveis para ajudar a empresa a melhorar.
-
-Regras IMPORTANTES:
-- Responda SEMPRE em JSON válido.
-- Não inclua comentários, texto fora do JSON ou explicações adicionais.
-- Use apenas os valores 'positive', 'neutral' ou 'negative' em "sentiment".
-- Em "categories" e "keywords", use arrays de strings curtas (ex.: ["atendimento", "preço"]).`;
-
-  const enterpriseContext = {
+  return {
     enterprise_name: enterpriseName,
-    company_objective: companyObjective,
-    analytics_goal: analyticsGoal,
-    business_summary: businessSummary,
-    main_products_or_services: mainProductsOrServices,
+    company_objective: collecting?.company_objective ?? null,
+    analytics_goal: collecting?.analytics_goal ?? null,
+    business_summary: collecting?.business_summary ?? null,
+    main_products_or_services: collecting?.main_products_or_services ?? null,
   };
+}
 
-  const payload = {
-    enterprise: enterpriseContext,
-    feedbacks: feedbacks,
+function groupFeedbacksByScope(feedbacks: FeedbackForAnalysis[]) {
+  const buckets = new Map<FeedbackScopeType, FeedbackForAnalysis[]>([
+    ['COMPANY', []],
+    ['PRODUCT', []],
+    ['SERVICE', []],
+    ['DEPARTMENT', []],
+  ]);
+
+  for (const feedback of feedbacks) {
+    const scope = normalizeScopeType(feedback.scope_type);
+    buckets.get(scope)?.push(feedback);
+  }
+
+  return Array.from(buckets.entries()).filter(([, items]) => items.length > 0);
+}
+
+function mergeGlobalInsights(
+  items: Array<{
+    scopeType: FeedbackScopeType;
+    insights: IaGlobalInsights | null;
+  }>,
+): IaGlobalInsights | null {
+  const valid = items.filter((entry) => {
+    const summary = entry.insights?.summary?.trim();
+    const recommendations = (entry.insights?.recommendations ?? []).filter(
+      (value) => String(value).trim().length > 0,
+    );
+
+    return Boolean(summary) || recommendations.length > 0;
+  });
+
+  if (valid.length === 0) {
+    return null;
+  }
+
+  if (valid.length === 1) {
+    const single = valid[0].insights!;
+    return {
+      summary: single.summary,
+      recommendations: single.recommendations,
+    };
+  }
+
+  const summaryParts = valid
+    .map((entry) => {
+      const summary = entry.insights?.summary?.trim();
+      if (!summary) return null;
+      return `[${entry.scopeType}] ${summary}`;
+    })
+    .filter((part): part is string => Boolean(part));
+
+  const recommendationSet = new Set<string>();
+
+  valid.forEach((entry) => {
+    (entry.insights?.recommendations ?? []).forEach((recommendation) => {
+      const text = String(recommendation ?? '').trim();
+      if (!text) return;
+      recommendationSet.add(text);
+    });
+  });
+
+  const recommendations = Array.from(recommendationSet);
+  const summary = summaryParts.length > 0 ? summaryParts.join('\n\n') : undefined;
+
+  if (!summary && recommendations.length === 0) {
+    return null;
+  }
+
+  return {
+    ...(summary ? { summary } : {}),
+    ...(recommendations.length > 0 ? { recommendations } : {}),
   };
+}
 
-  const expectedSchemaExample: {
-    feedbacks: IaFeedbackAnalysisItem[];
-    global_insights: IaGlobalInsights;
-  } = {
-    feedbacks: [
-      {
-        feedback_id: 'uuid-do-feedback',
-        sentiment: 'positive',
-        categories: ['atendimento', 'experiência'],
-        keywords: ['agilidade', 'cordialidade'],
+async function fetchFeedbacksForAnalysis(params: {
+  supabase: SupabaseServerClient;
+  enterpriseId: string;
+  limit: number;
+}) {
+  const { supabase, enterpriseId, limit } = params;
+
+  const { data: feedbacks, error: feedbackError } = await supabase
+    .from('feedback')
+    .select(
+      `
+      id,
+      message,
+      rating,
+      created_at,
+      collection_points(
+        id,
+        name,
+        type,
+        identifier,
+        catalog_item_id
+      )
+    `,
+    )
+    .eq('enterprise_id', enterpriseId)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (feedbackError) {
+    throw new IaStudioServiceError(
+      'Failed to fetch feedbacks for IA',
+      500,
+      'failed_to_fetch_feedbacks_for_ia',
+    );
+  }
+
+  const feedbackRows = (feedbacks ?? []) as RawFeedbackRow[];
+
+  const catalogItemIds = Array.from(
+    new Set(
+      feedbackRows
+        .map((feedback) => resolveCollectionPoint(feedback.collection_points)?.catalog_item_id)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0),
+    ),
+  );
+
+  let catalogItemById = new Map<
+    string,
+    {
+      id: string;
+      name: string;
+      kind: 'PRODUCT' | 'SERVICE' | 'DEPARTMENT';
+      description: string | null;
+    }
+  >();
+
+  if (catalogItemIds.length > 0) {
+    const { data: catalogRows, error: catalogError } = await supabase
+      .from('catalog_items')
+      .select('id, name, kind, description')
+      .in('id', catalogItemIds);
+
+    if (catalogError) {
+      throw new IaStudioServiceError(
+        'Failed to fetch catalog items for IA',
+        500,
+        'failed_to_fetch_catalog_items_for_ia',
+      );
+    }
+
+    catalogItemById = new Map(
+      ((catalogRows ?? []) as RawCatalogItemRow[])
+        .map((row) => {
+          const scopeType = normalizeScopeType(row.kind);
+          if (scopeType === 'COMPANY') return null;
+
+          return [
+            row.id,
+            {
+              id: row.id,
+              name: row.name,
+              kind: scopeType,
+              description: row.description ?? null,
+            },
+          ] as const;
+        })
+        .filter(
+          (
+            entry,
+          ): entry is readonly [
+            string,
+            {
+              id: string;
+              name: string;
+              kind: 'PRODUCT' | 'SERVICE' | 'DEPARTMENT';
+              description: string | null;
+            },
+          ] => Boolean(entry),
+        ),
+    );
+  }
+
+  const feedbackIds = feedbackRows
+    .map((feedback) => feedback.id)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+
+  const answersByFeedbackId = new Map<
+    string,
+    Array<{
+      question_id: string;
+      question_text_snapshot: string;
+      answer_value: 'PESSIMO' | 'RUIM' | 'MEDIANA' | 'BOA' | 'OTIMA';
+      answer_score: number;
+    }>
+  >();
+
+  if (feedbackIds.length > 0) {
+    const { data: answerRows, error: answersError } = await supabase
+      .from('feedback_question_answers')
+      .select(
+        'feedback_id, question_id, question_text_snapshot, answer_value, answer_score, created_at',
+      )
+      .in('feedback_id', feedbackIds)
+      .order('created_at', { ascending: true });
+
+    if (answersError) {
+      throw new IaStudioServiceError(
+        'Failed to fetch feedback dynamic answers for IA',
+        500,
+        'failed_to_fetch_feedback_dynamic_answers_for_ia',
+      );
+    }
+
+    ((answerRows ?? []) as RawFeedbackQuestionAnswerRow[]).forEach((answer) => {
+      const current = answersByFeedbackId.get(answer.feedback_id) ?? [];
+
+      current.push({
+        question_id: answer.question_id,
+        question_text_snapshot: answer.question_text_snapshot,
+        answer_value: answer.answer_value,
+        answer_score: answer.answer_score,
+      });
+
+      answersByFeedbackId.set(answer.feedback_id, current);
+    });
+  }
+
+  return feedbackRows.map((feedback) => {
+    const collectionPoint = resolveCollectionPoint(feedback.collection_points);
+
+    const catalogItemId =
+      typeof collectionPoint?.catalog_item_id === 'string'
+        ? collectionPoint.catalog_item_id
+        : null;
+
+    const catalogItem = catalogItemId
+      ? (catalogItemById.get(catalogItemId) ?? null)
+      : null;
+
+    const scopeType = normalizeScopeType(catalogItem?.kind ?? null);
+
+    return {
+      id: feedback.id,
+      message: feedback.message,
+      rating: feedback.rating ?? null,
+      created_at: feedback.created_at ?? null,
+      scope_type: scopeType,
+      collection_point: {
+        id: collectionPoint?.id ?? null,
+        name: collectionPoint?.name ?? null,
+        type: collectionPoint?.type ?? null,
+        identifier: collectionPoint?.identifier ?? null,
       },
-    ],
-    global_insights: {
-      summary:
-        'Resumo geral dos principais padrões encontrados nos feedbacks, em poucas frases.',
-      recommendations: [
-        'Sugestão objetiva 1 para melhorar a experiência.',
-        'Sugestão objetiva 2 para melhorar processos, produto ou atendimento.',
-      ],
-    },
-  };
-
-  return [
-    header,
-    '',
-    'Estrutura exata de resposta (NÃO altere as chaves):',
-    JSON.stringify(expectedSchemaExample, null, 2),
-    '',
-    'Dados de entrada (em JSON):',
-    JSON.stringify(payload),
-  ].join('\n');
+      catalog_item: catalogItem,
+      dynamic_answers: answersByFeedbackId.get(feedback.id) ?? [],
+    } satisfies FeedbackForAnalysis;
+  });
 }
 
 export async function analyzeFeedbacksForEnterprise(params: {
@@ -212,29 +473,11 @@ export async function analyzeFeedbacksForEnterprise(params: {
       ? Math.min(options.limit, 100)
       : 50;
 
-  const { data: feedbacks, error: feedbackError } = await supabase
-    .from('feedback')
-    .select('id, message, rating, created_at')
-    .eq('enterprise_id', enterpriseId)
-    .order('created_at', { ascending: false })
-    .limit(limit);
-
-  if (feedbackError) {
-    throw new IaStudioServiceError(
-      'Failed to fetch feedbacks for IA',
-      500,
-      'failed_to_fetch_feedbacks_for_ia',
-    );
-  }
-
-  const feedbacksForAnalysis: FeedbackForAnalysis[] = (feedbacks ?? []).map(
-    (f) => ({
-      id: f.id as string,
-      message: f.message as string,
-      rating: (f.rating as number | null) ?? null,
-      created_at: (f.created_at as string | null) ?? null,
-    }),
-  );
+  const feedbacksForAnalysis = await fetchFeedbacksForAnalysis({
+    supabase,
+    enterpriseId,
+    limit,
+  });
 
   if (feedbacksForAnalysis.length === 0) {
     return {
@@ -277,15 +520,12 @@ export async function analyzeFeedbacksForEnterprise(params: {
     };
   }
 
-  // 6) Montar prompt para o Gemini com contexto da empresa + feedbacks
-  const prompt = buildIaPrompt({
+  const enterpriseContext = buildEnterpriseContext({
     enterpriseName,
-    companyObjective: collecting?.company_objective ?? null,
-    analyticsGoal: collecting?.analytics_goal ?? null,
-    businessSummary: collecting?.business_summary ?? null,
-    mainProductsOrServices: collecting?.main_products_or_services ?? null,
-    feedbacks: feedbacksToAnalyze,
+    collecting: collecting as CollectingDataContext | null,
   });
+
+  const feedbackGroupsByScope = groupFeedbacksByScope(feedbacksToAnalyze);
 
   const apiKey = process.env.GEMINI_API_KEY;
   if (!apiKey) {
@@ -298,71 +538,104 @@ export async function analyzeFeedbacksForEnterprise(params: {
 
   const ai = new GoogleGenAI({ apiKey });
 
-  const aiResponse = await ai.models.generateContent({
-    model: 'gemini-2.5-flash',
-    contents: prompt,
-  });
-
-  type AiResponseShape = {
-    text?: string | (() => string);
-  };
-
-  const maybeText = (aiResponse as AiResponseShape).text;
-  const rawText =
-    (typeof maybeText === 'function' ? maybeText() : maybeText) ?? '';
-
-  let parsed:
-    | {
-        feedbacks?: IaFeedbackAnalysisItem[];
-        global_insights?: IaGlobalInsights;
-      }
-    | null = null;
-
-  try {
-    const jsonString = extractJsonFromText(rawText);
-    parsed = JSON.parse(jsonString) as {
-      feedbacks?: IaFeedbackAnalysisItem[];
-      global_insights?: IaGlobalInsights;
-    };
-  } catch {
-    // Log detalhado fica por conta de quem chama
-    throw new IaStudioServiceError(
-      'Invalid AI response JSON',
-      502,
-      'invalid_ai_response',
-    );
-  }
-
-  const items = Array.isArray(parsed?.feedbacks) ? parsed!.feedbacks : [];
-
   const validSentiments: Sentiment[] = ['positive', 'negative', 'neutral'];
   const validSentimentsSet = new Set(validSentiments);
 
-  const rowsToInsert = items
-    .filter((item) => {
-      return (
-        typeof item.feedback_id === 'string' &&
-        validSentimentsSet.has(item.sentiment) &&
-        feedbacksToAnalyze.some((f) => f.id === item.feedback_id)
+  const rowsByFeedbackId = new Map<
+    string,
+    {
+      feedback_id: string;
+      sentiment: Sentiment;
+      categories: string[];
+      keywords: string[];
+    }
+  >();
+
+  const insightsByScope: Array<{
+    scopeType: FeedbackScopeType;
+    insights: IaGlobalInsights | null;
+  }> = [];
+
+  for (const [scopeType, feedbackItems] of feedbackGroupsByScope) {
+    const prompt = buildIaPromptByScope({
+      scopeType,
+      enterpriseContext,
+      feedbacks: feedbackItems,
+    });
+
+    const aiResponse = await ai.models.generateContent({
+      model: 'gemini-2.5-flash',
+      contents: prompt,
+    });
+
+    type AiResponseShape = {
+      text?: string | (() => string);
+    };
+
+    const maybeText = (aiResponse as AiResponseShape).text;
+    const rawText =
+      (typeof maybeText === 'function' ? maybeText() : maybeText) ?? '';
+
+    let parsed:
+      | {
+          feedbacks?: IaFeedbackAnalysisItem[];
+          global_insights?: IaGlobalInsights;
+        }
+      | null = null;
+
+    try {
+      const jsonString = extractJsonFromText(rawText);
+      parsed = JSON.parse(jsonString) as {
+        feedbacks?: IaFeedbackAnalysisItem[];
+        global_insights?: IaGlobalInsights;
+      };
+    } catch {
+      throw new IaStudioServiceError(
+        'Invalid AI response JSON',
+        502,
+        'invalid_ai_response',
       );
-    })
-    .map((item) => ({
-      feedback_id: item.feedback_id,
-      sentiment: item.sentiment,
-      categories: Array.isArray(item.categories)
-        ? item.categories
-        : ([] as string[]),
-      keywords: Array.isArray(item.keywords)
-        ? item.keywords
-        : ([] as string[]),
-    }));
+    }
+
+    insightsByScope.push({
+      scopeType,
+      insights: parsed?.global_insights ?? null,
+    });
+
+    const items = Array.isArray(parsed?.feedbacks) ? parsed.feedbacks : [];
+    const allowedFeedbackIds = new Set(feedbackItems.map((item) => item.id));
+
+    items.forEach((item) => {
+      if (
+        typeof item.feedback_id !== 'string' ||
+        !validSentimentsSet.has(item.sentiment) ||
+        !allowedFeedbackIds.has(item.feedback_id)
+      ) {
+        return;
+      }
+
+      rowsByFeedbackId.set(item.feedback_id, {
+        feedback_id: item.feedback_id,
+        sentiment: item.sentiment,
+        categories: Array.isArray(item.categories)
+          ? item.categories
+          : ([] as string[]),
+        keywords: Array.isArray(item.keywords)
+          ? item.keywords
+          : ([] as string[]),
+      });
+    });
+  }
+
+  const rowsToInsert = Array.from(rowsByFeedbackId.values());
+
+  const globalInsights = mergeGlobalInsights(insightsByScope);
 
   if (rowsToInsert.length === 0) {
-    // IA respondeu sem itens válidos; não é erro fatal, apenas não há novos dados para salvar
     return {
       analyzedCount: 0,
       feedbacksAnalyzed: [],
-      globalInsights: parsed?.global_insights ?? null,
+      globalInsights,
     };
   }
 
@@ -380,9 +653,12 @@ export async function analyzeFeedbacksForEnterprise(params: {
   }
 
   // 7) Persistir relatório global de insights (summary + recommendations) por empresa
-  if (parsed?.global_insights) {
-    const summary = parsed.global_insights.summary ?? null;
-    const recommendations = parsed.global_insights.recommendations ?? null;
+  if (globalInsights) {
+    const summary = globalInsights.summary ?? null;
+    const recommendations =
+      globalInsights.recommendations && globalInsights.recommendations.length > 0
+        ? globalInsights.recommendations
+        : null;
 
     try {
       await supabase
@@ -412,7 +688,7 @@ export async function analyzeFeedbacksForEnterprise(params: {
         categories: (row.categories ?? []) as string[],
         keywords: (row.keywords ?? []) as string[],
       })) ?? [],
-    globalInsights: parsed?.global_insights ?? null,
+    globalInsights,
   };
 }
 

--- a/src/server/express/services/iaStudioService.ts
+++ b/src/server/express/services/iaStudioService.ts
@@ -56,6 +56,8 @@ export type IaStudioOptions = {
   catalog_item_id?: string;
 };
 
+const MIN_FEEDBACKS_FOR_RELEVANT_ANALYSIS = 10;
+
 type AnalysisBatch = {
   scopeType: FeedbackScopeType;
   catalogItemId: string | null;
@@ -549,6 +551,14 @@ export async function analyzeFeedbacksForEnterprise(params: {
       globalInsights: null,
       contexts: [],
     };
+  }
+
+  if (feedbacksForExecution.length < MIN_FEEDBACKS_FOR_RELEVANT_ANALYSIS) {
+    throw new IaStudioServiceError(
+      'insufficient_feedbacks_for_analysis',
+      422,
+      'insufficient_feedbacks_for_analysis',
+    );
   }
 
   // 5) Evitar reprocessar feedbacks já analisados buscando os IDs já presentes em feedback_analysis

--- a/src/server/express/services/iaStudioService.ts
+++ b/src/server/express/services/iaStudioService.ts
@@ -187,6 +187,169 @@ function buildEnterpriseContext(params: {
   };
 }
 
+const STRUCTURED_ANSWER_LABELS = new Set<string>([
+  'pessimo',
+  'ruim',
+  'mediana',
+  'boa',
+  'otima',
+]);
+
+const PORTUGUESE_STOPWORDS = new Set<string>([
+  'a',
+  'ao',
+  'aos',
+  'as',
+  'com',
+  'da',
+  'das',
+  'de',
+  'do',
+  'dos',
+  'e',
+  'em',
+  'na',
+  'nas',
+  'no',
+  'nos',
+  'o',
+  'os',
+  'para',
+  'por',
+  'que',
+  'sem',
+  'um',
+  'uma',
+]);
+
+function normalizeForComparison(value: string) {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function tokenizeRelevantWords(value: string) {
+  return normalizeForComparison(value)
+    .split(' ')
+    .map((token) => token.trim())
+    .filter(
+      (token) =>
+        token.length >= 4 &&
+        !PORTUGUESE_STOPWORDS.has(token) &&
+        !STRUCTURED_ANSWER_LABELS.has(token),
+    );
+}
+
+function isGroundedInMessage(termNormalized: string, messageNormalized: string) {
+  if (!termNormalized || !messageNormalized) {
+    return false;
+  }
+
+  if (messageNormalized.includes(termNormalized)) {
+    return true;
+  }
+
+  const termTokens = tokenizeRelevantWords(termNormalized);
+  if (termTokens.length === 0) {
+    return false;
+  }
+
+  const messageTokens = new Set(tokenizeRelevantWords(messageNormalized));
+
+  return termTokens.some((token) => messageTokens.has(token));
+}
+
+function fallbackKeywordsFromMessage(message: string, maxCount: number) {
+  const tokens = tokenizeRelevantWords(message);
+  const unique = Array.from(new Set(tokens));
+  return unique.slice(0, maxCount);
+}
+
+function sanitizeTermList(params: {
+  terms: string[];
+  messageNormalized: string;
+  forbiddenTerms: Set<string>;
+  maxCount: number;
+}) {
+  const { terms, messageNormalized, forbiddenTerms, maxCount } = params;
+  const result: string[] = [];
+  const seen = new Set<string>();
+
+  for (const value of terms) {
+    const rawTerm = String(value ?? '').trim();
+    if (!rawTerm) continue;
+
+    const normalizedTerm = normalizeForComparison(rawTerm);
+    if (!normalizedTerm) continue;
+    if (forbiddenTerms.has(normalizedTerm)) continue;
+    if (!isGroundedInMessage(normalizedTerm, messageNormalized)) continue;
+    if (seen.has(normalizedTerm)) continue;
+
+    seen.add(normalizedTerm);
+    result.push(normalizedTerm);
+
+    if (result.length >= maxCount) {
+      break;
+    }
+  }
+
+  return result;
+}
+
+function sanitizeAnalysisTerms(params: {
+  feedback: FeedbackForAnalysis;
+  categories: string[];
+  keywords: string[];
+}) {
+  const { feedback, categories, keywords } = params;
+
+  const messageNormalized = normalizeForComparison(feedback.message ?? '');
+  const forbiddenTerms = new Set<string>(STRUCTURED_ANSWER_LABELS);
+
+  feedback.dynamic_answers.forEach((answer) => {
+    const normalizedAnswerValue = normalizeForComparison(answer.answer_value);
+    if (normalizedAnswerValue) {
+      forbiddenTerms.add(normalizedAnswerValue);
+    }
+
+    const normalizedQuestion = normalizeForComparison(answer.question_text_snapshot);
+    if (normalizedQuestion) {
+      forbiddenTerms.add(normalizedQuestion);
+    }
+  });
+
+  let sanitizedKeywords = sanitizeTermList({
+    terms: keywords,
+    messageNormalized,
+    forbiddenTerms,
+    maxCount: 6,
+  });
+
+  if (sanitizedKeywords.length === 0) {
+    sanitizedKeywords = fallbackKeywordsFromMessage(feedback.message ?? '', 4);
+  }
+
+  let sanitizedCategories = sanitizeTermList({
+    terms: categories,
+    messageNormalized,
+    forbiddenTerms,
+    maxCount: 4,
+  });
+
+  if (sanitizedCategories.length === 0) {
+    sanitizedCategories = sanitizedKeywords.slice(0, 2);
+  }
+
+  return {
+    categories: sanitizedCategories,
+    keywords: sanitizedKeywords,
+  };
+}
+
 function applyExecutionFilter(
   feedbacks: FeedbackForAnalysis[],
   options?: IaStudioOptions,
@@ -688,6 +851,7 @@ export async function analyzeFeedbacksForEnterprise(params: {
 
     const items = Array.isArray(parsed?.feedbacks) ? parsed.feedbacks : [];
     const allowedFeedbackIds = new Set(batch.feedbacks.map((item) => item.id));
+    const feedbackById = new Map(batch.feedbacks.map((feedback) => [feedback.id, feedback]));
 
     items.forEach((item) => {
       if (
@@ -698,15 +862,26 @@ export async function analyzeFeedbacksForEnterprise(params: {
         return;
       }
 
-      rowsByFeedbackId.set(item.feedback_id, {
-        feedback_id: item.feedback_id,
-        sentiment: item.sentiment,
+      const sourceFeedback = feedbackById.get(item.feedback_id);
+      if (!sourceFeedback) {
+        return;
+      }
+
+      const sanitizedTerms = sanitizeAnalysisTerms({
+        feedback: sourceFeedback,
         categories: Array.isArray(item.categories)
           ? item.categories
           : ([] as string[]),
         keywords: Array.isArray(item.keywords)
           ? item.keywords
           : ([] as string[]),
+      });
+
+      rowsByFeedbackId.set(item.feedback_id, {
+        feedback_id: item.feedback_id,
+        sentiment: item.sentiment,
+        categories: sanitizedTerms.categories,
+        keywords: sanitizedTerms.keywords,
       });
     });
   }

--- a/src/services/serviceFeedbacks.ts
+++ b/src/services/serviceFeedbacks.ts
@@ -5,6 +5,9 @@ import type {
   FeedbackAnalysisResponse,
   FeedbackSentiment,
   FeedbackInsightsReport,
+  FeedbackAnalysisOptions,
+  FeedbackInsightsReportOptions,
+  FeedbackInsightScopeType,
 } from 'lib/interfaces/domain/feedback.domain';
 import { getJson, postJson } from '../../lib/utils/http';
 
@@ -30,13 +33,19 @@ export function ServiceGetFeedbackStats() {
   return getJson<FeedbackStats>('/api/protected/user/feedbacks/stats');
 }
 
-export function ServiceGetFeedbackAnalysis(params?: {
-  sentiment?: FeedbackSentiment;
-}) {
+export function ServiceGetFeedbackAnalysis(params?: FeedbackAnalysisOptions) {
   const searchParams = new URLSearchParams();
 
   if (params?.sentiment) {
     searchParams.append('sentiment', params.sentiment);
+  }
+
+  if (params?.scope_type) {
+    searchParams.append('scope_type', params.scope_type);
+  }
+
+  if (params?.catalog_item_id) {
+    searchParams.append('catalog_item_id', params.catalog_item_id);
   }
 
   const queryString = searchParams.toString();
@@ -47,9 +56,26 @@ export function ServiceGetFeedbackAnalysis(params?: {
   return getJson<FeedbackAnalysisResponse>(url);
 }
 
-export function ServiceGetFeedbackInsightsReport() {
+export function ServiceGetFeedbackInsightsReport(
+  params?: FeedbackInsightsReportOptions,
+) {
+  const searchParams = new URLSearchParams();
+
+  if (params?.scope_type) {
+    searchParams.append('scope_type', params.scope_type);
+  }
+
+  if (params?.catalog_item_id) {
+    searchParams.append('catalog_item_id', params.catalog_item_id);
+  }
+
+  const queryString = searchParams.toString();
+  const url = `/api/protected/user/feedbacks/insights/report${
+    queryString ? `?${queryString}` : ''
+  }`;
+
   return getJson<FeedbackInsightsReport>(
-    '/api/protected/user/feedbacks/insights/report',
+    url,
   );
 }
 
@@ -61,7 +87,13 @@ export interface FeedbackIaRunResult {
   } | null;
 }
 
-export function ServiceRunFeedbackIAAnalysis(options?: { limit?: number }) {
+export type FeedbackIaRunOptions = {
+  limit?: number;
+  scope_type?: FeedbackInsightScopeType;
+  catalog_item_id?: string;
+};
+
+export function ServiceRunFeedbackIAAnalysis(options?: FeedbackIaRunOptions) {
   return postJson<FeedbackIaRunResult>(
     '/api/protected/ia-studio/send-message',
     options ?? {},

--- a/src/services/serviceFeedbacks.ts
+++ b/src/services/serviceFeedbacks.ts
@@ -3,7 +3,6 @@ import type {
   FeedbackStats,
   FeedbackFilters,
   FeedbackAnalysisResponse,
-  FeedbackSentiment,
   FeedbackInsightsReport,
   FeedbackAnalysisOptions,
   FeedbackInsightsReportOptions,


### PR DESCRIPTION
Bloqueio na UI (botões desabilitados)

O botão de análise em feedbackInsightsReport.tsx agora depende de um guard vindo do loader.

No cabeçalho InsightsReportHeaderSection.tsx, o botão fica desabilitado quando os dados da empresa não estão completos.

Mensagem obrigatória para o usuário

Exibida mensagem clara informando que precisa preencher dados da empresa.

Incluído link direto para configuração: /user/edit/collecting-data-enterprise

Mensagem exibida no próprio header de insights.

Regra de completude no loader

Em loadFeedbackInsightsReport.ts, criei verificação de completude:

company_objective analytics_goal

business_summary

O loader retorna analysisGuard com canAnalyze e message para a tela.

Segurança no backend (não só frontend)

Em iaStudioService.ts, adicionei validação obrigatória dos mesmos campos antes de processar IA.

Se faltar, retorna erro collecting_data_required_for_analysis (422), impedindo bypass via chamada direta.

Tratamento do erro na action

Em actionFeedbackInsightsReport.ts, mapeei collecting_data_required_for_analysis para mensagem amigável.

Também atualizei o tipo em ui.types.ts.