### PR TITLE
Etapa 1 já estava correta no arquivo EndpointResendConfirmation.ts:1, com imports ESM usando extensão .js.

### DIFF
--- a/src/server/express/endpoints/protected/EndpointsEnterprise.ts
+++ b/src/server/express/endpoints/protected/EndpointsEnterprise.ts
@@ -63,19 +63,25 @@ type CollectingDataPayload = {
   company_feedback_questions?: CompanyFeedbackQuestionInput[] | null;
 };
 
-const DEFAULT_COMPANY_FEEDBACK_QUESTIONS = [
+const DEFAULT_COMPANY_FEEDBACK_QUESTIONS: CompanyFeedbackQuestionInput[] = [
   {
     question_order: 1,
     question_text: 'Como foi sua experiência em relação ao atendimento?',
+    is_active: true,
+    subquestions: [],
   },
   {
     question_order: 2,
     question_text: 'O que você achou da qualidade do produto/serviço?',
+    is_active: true,
+    subquestions: [],
   },
   {
     question_order: 3,
     question_text:
       'Como você avalia a relação entre o valor pago e a qualidade do produto/serviço?',
+    is_active: true,
+    subquestions: [],
   },
 ];
 

--- a/src/server/express/endpoints/protected/EndpointsFeedbacks.ts
+++ b/src/server/express/endpoints/protected/EndpointsFeedbacks.ts
@@ -21,6 +21,28 @@ type FeedbackQuestionAnswerRow = {
   created_at: string;
 };
 
+type FeedbackCollectionPoint = {
+  id?: string;
+  name?: string;
+  type?: string;
+  identifier?: string | null;
+  catalog_item_id?: string | null;
+};
+
+function resolveCollectionPoint(
+  collectionPointRaw:
+    | FeedbackCollectionPoint
+    | FeedbackCollectionPoint[]
+    | null
+    | undefined,
+) {
+  if (Array.isArray(collectionPointRaw)) {
+    return collectionPointRaw[0] ?? null;
+  }
+
+  return collectionPointRaw ?? null;
+}
+
 function parseInsightScopeType(rawValue: unknown) {
   const normalized = String(rawValue ?? '').trim().toUpperCase();
 
@@ -242,7 +264,7 @@ export function EndpointsFeedbacks(app: express.Express) {
       const catalogItemIds = Array.from(
         new Set(
           (feedbacks ?? [])
-            .map((feedback) => feedback.collection_points?.catalog_item_id)
+            .map((feedback) => resolveCollectionPoint(feedback.collection_points)?.catalog_item_id)
             .filter((id): id is string => typeof id === 'string' && id.length > 0),
         ),
       );
@@ -282,7 +304,7 @@ export function EndpointsFeedbacks(app: express.Express) {
       }
 
       const normalizedFeedbacks = (feedbacks ?? []).map((feedback) => {
-        const collectionPoint = feedback.collection_points;
+        const collectionPoint = resolveCollectionPoint(feedback.collection_points);
 
         if (!collectionPoint) {
           return feedback;


### PR DESCRIPTION
Etapa 2 aplicada em EndpointsEnterprise.ts:63: o default de perguntas agora está tipado como CompanyFeedbackQuestionInput[] e inclui is_active + subquestions em todos os itens. Etapa 3 aplicada em EndpointsFeedbacks.ts:21: adicionei normalização de collection_points (objeto ou array) e passei a usar isso nos acessos de catalog_item_id em EndpointsFeedbacks.ts:264 e EndpointsFeedbacks.ts:304.