### PR TITLE
Separando workflows homolog, main.

### DIFF
--- a/.github/workflows/deploy-api-homolog.yml
+++ b/.github/workflows/deploy-api-homolog.yml
@@ -1,0 +1,54 @@
+name: Deploy Api Gateway (Vercel) — Homolog
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm_homolog_deploy:
+        description: "Digite DEPLOY para confirmar deploy de homolog"
+        required: true
+        type: string
+
+concurrency:
+  group: deploy-api-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-api-gateway-homolog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate manual deploy request
+        run: |
+          if [ "${{ github.ref_name }}" != "homolog" ]; then
+            echo "Este workflow deve ser executado apenas na branch homolog"
+            exit 1
+          fi
+
+          if [ "${{ github.event.inputs.confirm_homolog_deploy }}" != "DEPLOY" ]; then
+            echo "Confirme o deploy informando DEPLOY"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: |
+            backends/api-gateway/package-lock.json
+            shared/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          npm ci --prefix shared
+          npm ci --prefix backends/api-gateway
+
+      - name: Deploy preview (homolog)
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_API_GATEWAY }}
+        run: npx vercel deploy --yes --token "$VERCEL_TOKEN" --local-config backends/api-gateway/vercel.json

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,4 +1,4 @@
-name: Deploy Api Gateway (Vercel)
+name: Deploy Api Gateway (Vercel) — Production
 
 on:
   push:
@@ -14,12 +14,6 @@ on:
       - "backends/api-gateway/package.json"
       - "backends/api-gateway/package-lock.json"
       - ".github/workflows/deploy-api.yml"
-  workflow_dispatch:
-    inputs:
-      confirm_homolog_deploy:
-        description: "Digite DEPLOY para confirmar deploy de homolog"
-        required: true
-        type: string
 
 concurrency:
   group: deploy-api-${{ github.ref_name }}
@@ -32,19 +26,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Validate manual deploy request
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          if [ "${{ github.ref_name }}" != "homolog" ]; then
-            echo "workflow_dispatch permitido apenas para a branch homolog"
-            exit 1
-          fi
-
-          if [ "${{ github.event.inputs.confirm_homolog_deploy }}" != "DEPLOY" ]; then
-            echo "Confirme o deploy informando DEPLOY"
-            exit 1
-          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -60,16 +41,7 @@ jobs:
           npm ci --prefix shared
           npm ci --prefix backends/api-gateway
 
-      - name: Deploy preview (homolog)
-        if: github.event_name == 'workflow_dispatch' && github.ref_name == 'homolog' && github.event.inputs.confirm_homolog_deploy == 'DEPLOY'
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_API_GATEWAY }}
-        run: npx vercel deploy --yes --token "$VERCEL_TOKEN" --local-config backends/api-gateway/vercel.json
-
       - name: Deploy production (main)
-        if: github.event_name == 'push' && github.ref_name == 'main'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/deploy-ia-analyze-homolog.yml
+++ b/.github/workflows/deploy-ia-analyze-homolog.yml
@@ -1,0 +1,79 @@
+name: Deploy IA Analyze Service (Vercel) — Homolog
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm_homolog_deploy:
+        description: "Digite DEPLOY para confirmar deploy de homolog"
+        required: true
+        type: string
+
+concurrency:
+  group: deploy-ia-analyze-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-ia-analyze-homolog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate manual deploy request
+        run: |
+          if [ "${{ github.ref_name }}" != "homolog" ]; then
+            echo "Este workflow deve ser executado apenas na branch homolog"
+            exit 1
+          fi
+
+          if [ "${{ github.event.inputs.confirm_homolog_deploy }}" != "DEPLOY" ]; then
+            echo "Confirme o deploy informando DEPLOY"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: |
+            services/ia-analyze/package-lock.json
+            shared/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          npm ci --prefix shared
+          npm ci --prefix services/ia-analyze
+
+      - name: Deploy preview (homolog)
+        id: deploy_preview
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets['VERCEL_PROJECT_ID_IA_ANALYZE'] }}
+        run: |
+          set -eo pipefail
+          DEPLOY_URL=$(npx vercel deploy --yes --token "$VERCEL_TOKEN" --local-config services/ia-analyze/vercel.json 2>&1 | tee /tmp/vercel-ia-deploy.log | awk '/^https:\/\//{url=$1} END{print url}')
+
+          if [ -z "$DEPLOY_URL" ]; then
+            echo "Nao foi possivel extrair a URL do preview do ia-analyze."
+            exit 1
+          fi
+
+          echo "preview_url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
+          echo "Preview URL: $DEPLOY_URL"
+
+      - name: Set preview alias (homolog)
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          IA_ANALYZE_PREVIEW_ALIAS: feedback-analytics-service-ia-analysis-homolog.vercel.app
+        run: |
+          PREVIEW_URL="${{ steps.deploy_preview.outputs.preview_url }}"
+
+          if [ -z "$PREVIEW_URL" ]; then
+            echo "URL de preview vazia; nao foi possivel configurar alias."
+            exit 1
+          fi
+
+          npx vercel alias set "$PREVIEW_URL" "$IA_ANALYZE_PREVIEW_ALIAS" --token "$VERCEL_TOKEN" || echo "Aviso: nao foi possivel atualizar o alias de preview do ia-analyze."

--- a/.github/workflows/deploy-ia-analyze.yml
+++ b/.github/workflows/deploy-ia-analyze.yml
@@ -1,4 +1,4 @@
-name: Deploy IA Analyze Service (Vercel)
+name: Deploy IA Analyze Service (Vercel) — Production
 
 on:
   push:
@@ -11,12 +11,6 @@ on:
       - "shared/package.json"
       - "shared/package-lock.json"
       - ".github/workflows/deploy-ia-analyze.yml"
-  workflow_dispatch:
-    inputs:
-      confirm_homolog_deploy:
-        description: "Digite DEPLOY para confirmar deploy de homolog"
-        required: true
-        type: string
 
 concurrency:
   group: deploy-ia-analyze-${{ github.ref_name }}
@@ -29,19 +23,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Validate manual deploy request
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          if [ "${{ github.ref_name }}" != "homolog" ]; then
-            echo "workflow_dispatch permitido apenas para a branch homolog"
-            exit 1
-          fi
-
-          if [ "${{ github.event.inputs.confirm_homolog_deploy }}" != "DEPLOY" ]; then
-            echo "Confirme o deploy informando DEPLOY"
-            exit 1
-          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -57,42 +38,7 @@ jobs:
           npm ci --prefix shared
           npm ci --prefix services/ia-analyze
 
-      - name: Deploy preview (homolog)
-        if: github.event_name == 'workflow_dispatch' && github.ref_name == 'homolog' && github.event.inputs.confirm_homolog_deploy == 'DEPLOY'
-        id: deploy_preview
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets['VERCEL_PROJECT_ID_IA_ANALYZE'] }}
-        run: |
-          set -eo pipefail
-          DEPLOY_URL=$(npx vercel deploy --yes --token "$VERCEL_TOKEN" --local-config services/ia-analyze/vercel.json 2>&1 | tee /tmp/vercel-ia-deploy.log | awk '/^https:\/\//{url=$1} END{print url}')
-
-          if [ -z "$DEPLOY_URL" ]; then
-            echo "Nao foi possivel extrair a URL do preview do ia-analyze."
-            exit 1
-          fi
-
-          echo "preview_url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
-          echo "Preview URL: $DEPLOY_URL"
-
-      - name: Set preview alias (homolog)
-        if: github.event_name == 'workflow_dispatch' && github.ref_name == 'homolog' && github.event.inputs.confirm_homolog_deploy == 'DEPLOY'
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          IA_ANALYZE_PREVIEW_ALIAS: feedback-analytics-service-ia-analysis-homolog.vercel.app
-        run: |
-          PREVIEW_URL="${{ steps.deploy_preview.outputs.preview_url }}"
-
-          if [ -z "$PREVIEW_URL" ]; then
-            echo "URL de preview vazia; nao foi possivel configurar alias."
-            exit 1
-          fi
-
-          npx vercel alias set "$PREVIEW_URL" "$IA_ANALYZE_PREVIEW_ALIAS" --token "$VERCEL_TOKEN" || echo "Aviso: nao foi possivel atualizar o alias de preview do ia-analyze."
-
       - name: Deploy production (main)
-        if: github.event_name == 'push' && github.ref_name == 'main'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/deploy-web-homolog.yml
+++ b/.github/workflows/deploy-web-homolog.yml
@@ -1,0 +1,54 @@
+name: Deploy Web (Vercel) — Homolog
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm_homolog_deploy:
+        description: "Digite DEPLOY para confirmar deploy de homolog"
+        required: true
+        type: string
+
+concurrency:
+  group: deploy-web-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-web-homolog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate manual deploy request
+        run: |
+          if [ "${{ github.ref_name }}" != "homolog" ]; then
+            echo "Este workflow deve ser executado apenas na branch homolog"
+            exit 1
+          fi
+
+          if [ "${{ github.event.inputs.confirm_homolog_deploy }}" != "DEPLOY" ]; then
+            echo "Confirme o deploy informando DEPLOY"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: |
+            apps/web/package-lock.json
+            shared/package-lock.json
+
+      - name: Install dependecies
+        run: |
+          npm ci --prefix shared
+          npm ci --prefix apps/web
+
+      - name: Deploy preview (homolog)
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_WEB }}
+        run: npx vercel deploy --yes --token "$VERCEL_TOKEN" --local-config apps/web/vercel.json

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,4 +1,4 @@
-name: Deploy Web (Vercel)
+name: Deploy Web (Vercel) — Production
 
 on:
   push:
@@ -7,12 +7,6 @@ on:
       - "backends/api-gateway/**"
       - "database/**"
       - "services/ia-analyze/**"
-  workflow_dispatch:
-    inputs:
-      confirm_homolog_deploy:
-        description: "Digite DEPLOY para confirmar deploy de homolog"
-        required: true
-        type: string
 
 concurrency:
   group: deploy-web-${{ github.ref_name }}
@@ -25,19 +19,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Validate manual deploy request
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          if [ "${{ github.ref_name }}" != "homolog" ]; then
-            echo "workflow_dispatch permitido apenas para a branch homolog"
-            exit 1
-          fi
-
-          if [ "${{ github.event.inputs.confirm_homolog_deploy }}" != "DEPLOY" ]; then
-            echo "Confirme o deploy informando DEPLOY"
-            exit 1
-          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -53,16 +34,7 @@ jobs:
           npm ci --prefix shared
           npm ci --prefix apps/web
 
-      - name: Deploy preview (homolog)
-        if: github.event_name == 'workflow_dispatch' && github.ref_name == 'homolog' && github.event.inputs.confirm_homolog_deploy == 'DEPLOY'
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_WEB }}
-        run: npx vercel deploy --yes --token "$VERCEL_TOKEN" --local-config apps/web/vercel.json
-
       - name: Deploy production (main)
-        if: github.event_name == 'push' && github.ref_name == 'main'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
O GitHub não tem suporte a inputs condicionais por branch no workflow_dispatch — o formulário é sempre o mesmo independente da branch selecionada. A única saída real é separar em arquivos diferentes, porque o "Run workflow" aparece por arquivo, não por branch.