### PR TITLE
1. Card de header mais compacto — saí do título gigante (text-4xl) + coluna de botões para uma única linha. A saudação caiu para text-xl/2xl e o card ficou bem mais baixo. Mantive o CardSimple type="header" (gradiente/banner) para não destoar do resto.

### DIFF
--- a/apps/web/components/user/pages/dashboard/SectionMetric.tsx
+++ b/apps/web/components/user/pages/dashboard/SectionMetric.tsx
@@ -13,12 +13,6 @@ export default function SectionMetric({ totalFeedbacks, averageRating, positive,
   return (
     <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
       <MetricCard
-        title="Feedbacks recebidos"
-        value={FormatToCurrencyReal(totalFeedbacks)}
-        helper="Total acumulado no workspace"
-        icon={FaComments}
-      />
-      <MetricCard
         title="Média de satisfação"
         value={FormatToCurrencyReal(averageRating, {
           minimumFractionDigits: 1,
@@ -26,6 +20,12 @@ export default function SectionMetric({ totalFeedbacks, averageRating, positive,
         })}
         helper="Avaliação média em estrelas"
         icon={FaStar}
+      />
+      <MetricCard
+        title="Feedbacks recebidos"
+        value={FormatToCurrencyReal(totalFeedbacks)}
+        helper="Total acumulado no workspace"
+        icon={FaComments}
       />
       <MetricCard
         title="Feedbacks positivos"

--- a/apps/web/components/user/pages/dashboard/ShareQrCard.tsx
+++ b/apps/web/components/user/pages/dashboard/ShareQrCard.tsx
@@ -1,0 +1,83 @@
+import { Link } from "react-router-dom";
+import { FaArrowRight } from "react-icons/fa";
+
+/**
+ * CTA compacto de compartilhamento: um mini QR Code decorativo (com linha de
+ * leitura deslizante) que leva ao formulário/QR do escopo selecionado. O
+ * destino (`to`) é calculado no dashboard e varia conforme o escopo.
+ *
+ * O QR é apenas ilustrativo — o código real (escaneável) vive na tela de
+ * configuração do formulário, para onde este atalho aponta.
+ */
+
+// Módulos de dados do QR ilustrativo (posições em viewBox 100x100, fora dos
+// três "olhos" de canto). Sem valor escaneável — só estética.
+const QR_MODULES: ReadonlyArray<readonly [number, number]> = [
+  [40, 10], [51, 10], [40, 21],
+  [40, 40], [51, 51], [62, 40], [40, 62], [51, 40], [62, 62],
+  [70, 40], [81, 51], [70, 62],
+  [40, 70], [51, 81], [62, 70],
+  [70, 70], [81, 81], [70, 81], [81, 70],
+];
+
+function QrEye({ x, y }: { x: number; y: number }) {
+  return (
+    <>
+      <rect
+        x={x}
+        y={y}
+        width={22}
+        height={22}
+        rx={5}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={4}
+      />
+      <rect x={x + 7} y={y + 7} width={8} height={8} rx={2} fill="currentColor" />
+    </>
+  );
+}
+
+export default function ShareQrCard({ to }: { to: string }) {
+  return (
+    <Link
+      to={to}
+      aria-label="Compartilhar o formulário de feedback pelo QR Code"
+      className="group flex items-center gap-4 rounded-xl border border-(--primary-color)/25 bg-(--primary-color)/8 px-4 py-3 transition-all hover:border-(--primary-color)/50 hover:bg-(--primary-color)/12"
+    >
+      <span className="qr-anim relative grid h-14 w-14 shrink-0 place-items-center overflow-hidden rounded-lg border border-(--primary-color)/30 bg-(--bg-primary)/40">
+        <svg
+          viewBox="0 0 100 100"
+          aria-hidden
+          className="h-10 w-10 text-(--text-primary)"
+        >
+          <QrEye x={8} y={8} />
+          <QrEye x={70} y={8} />
+          <QrEye x={8} y={70} />
+          {QR_MODULES.map(([x, y]) => (
+            <rect
+              key={`${x}-${y}`}
+              x={x}
+              y={y}
+              width={8}
+              height={8}
+              rx={2}
+              fill="currentColor"
+            />
+          ))}
+        </svg>
+        <span className="qr-anim__scan" aria-hidden />
+      </span>
+
+      <span className="min-w-0">
+        <span className="font-poppins flex items-center gap-1.5 text-sm font-semibold text-(--text-primary)">
+          Utilize o QR Code
+          <FaArrowRight className="text-[0.65rem] text-(--primary-color) transition-transform group-hover:translate-x-0.5" />
+        </span>
+        <span className="mt-0.5 block text-xs text-(--text-tertiary)">
+          Compartilhe o formulário e colete feedbacks
+        </span>
+      </span>
+    </Link>
+  );
+}

--- a/apps/web/pages/tests/dashboard.test.tsx
+++ b/apps/web/pages/tests/dashboard.test.tsx
@@ -128,13 +128,14 @@ describe('[Unidade] Dashboard Page', () => {
       </MemoryRouter>,
     );
 
-    expect(
-      screen.getByText('Acompanhe as métricas e os insights dos seus feedbacks no escopo selecionado.'),
-    ).toBeInTheDocument();
-
     await waitFor(() => {
       expect(screen.getByText('Olá, Usuário Teste')).toBeInTheDocument();
     });
+
+    // Sem feedbacks pendentes (pendingCount ausente) → linha de status "em dia".
+    expect(
+      screen.getByText('Tudo em dia — nenhum feedback aguardando análise neste escopo.'),
+    ).toBeInTheDocument();
   });
 
   it('exibe métricas principais após carregar estatísticas', async () => {

--- a/apps/web/pages/user/dashboard.tsx
+++ b/apps/web/pages/user/dashboard.tsx
@@ -10,6 +10,7 @@ import {
   FaArrowRight,
 } from 'react-icons/fa';
 import SectionMetric from 'components/user/pages/dashboard/SectionMetric';
+import ShareQrCard from 'components/user/pages/dashboard/ShareQrCard';
 import SectionEvaluationDistribution from 'components/user/pages/dashboard/SectionEvaluationDistribution';
 import SectionSatisfactionRadar from 'components/user/pages/dashboard/SectionSatisfactionRadar';
 import SectionLowestQuestions from 'components/user/pages/dashboard/SectionLowestQuestions';
@@ -18,6 +19,7 @@ import InsightsReportContent from 'components/user/pages/feedbacksInsightsReport
 import { useToast } from 'components/public/forms/messages/useToast';
 import { useInsightsControls } from 'src/lib/context/insightsControls';
 import { useScopedInsightsReport } from 'src/lib/hooks/useScopedInsightsReport';
+import { getCatalogKindByKind } from 'src/lib/constants/catalog';
 import {
   ServiceGetFeedbackStats,
   ServiceGetFeedbackQuestions,
@@ -90,6 +92,17 @@ export default function Dashboard() {
   // Relatório de insights (resumo + recomendações), também filtrado por escopo.
   const { report, loading: reportLoading } = useScopedInsightsReport();
 
+  // O link de compartilhar segue o escopo selecionado no header: empresa → QR
+  // geral; produto/serviço/departamento com item escolhido → QR do item; tipo
+  // selecionado sem item → catálogo do tipo, para o gestor escolher o item.
+  const shareFormPath = (() => {
+    if (scope === 'COMPANY') return '/user/qrcode/enterprise';
+    const config = getCatalogKindByKind(scope);
+    if (!config) return '/user/qrcode/enterprise';
+    if (!catalogItemId) return config.listPath;
+    return `/user/edit/feedback/${config.slug}/${catalogItemId}`;
+  })();
+
   const displayName =
     user?.user_metadata?.full_name || enterprise?.full_name || user?.email || 'Dashboard';
 
@@ -97,32 +110,35 @@ export default function Dashboard() {
   const averageRating = stats?.averageRating ?? 0;
   const positive = stats?.sentimentBreakdown.positive ?? 0;
   const negative = stats?.sentimentBreakdown.negative ?? 0;
+  const pendingCount = stats?.pendingCount ?? 0;
 
   return (
     <div className="font-work-sans space-y-6">
       <CardSimple type="header">
         <div className="flex-1 space-y-2">
-          <p className="text-sm uppercase tracking-wide text-(--text-tertiary)">Visão Geral</p>
-          <h1 className="font-montserrat text-3xl font-semibold text-(--text-primary) md:text-4xl">
+          <p className="text-xs uppercase tracking-wide text-(--text-tertiary)">Visão geral</p>
+          <h1 className="font-montserrat text-xl font-semibold text-(--text-primary) md:text-2xl">
             Olá, {displayName}
           </h1>
-          <p className="text-sm text-(--text-secondary) md:text-base">
-            Acompanhe as métricas e os insights dos seus feedbacks no escopo selecionado.
+          <p className="flex items-center gap-1.5 text-sm text-(--text-secondary)">
+            {pendingCount > 0 && (
+              <span className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-(--primary-color)" />
+            )}
+            {totalFeedbacks === 0
+              ? 'Compartilhe o formulário pelo QR Code para começar a coletar feedbacks.'
+              : pendingCount > 0
+                ? `${pendingCount} ${pendingCount === 1 ? 'feedback aguardando' : 'feedbacks aguardando'} análise neste escopo.`
+                : 'Tudo em dia — nenhum feedback aguardando análise neste escopo.'}
           </p>
-        </div>
-        <div className="flex flex-col gap-3 md:items-end">
           <Link
             to="/user/feedbacks/all"
-            className="btn-primary font-poppins inline-flex items-center gap-2 px-5 py-3 text-sm font-semibold">
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-(--text-secondary) transition-colors hover:text-(--text-primary)">
             Ver feedbacks
-            <FaArrowRight className="text-xs" />
+            <FaArrowRight className="text-[0.6rem]" />
           </Link>
-          <Link
-            to="/user/qrcode/enterprise"
-            className="inline-flex items-center gap-2 text-sm text-(--text-secondary) transition-colors hover:text-(--text-primary)">
-            Compartilhar formulário de feedback
-            <FaArrowRight className="text-xs" />
-          </Link>
+        </div>
+        <div className="md:self-center">
+          <ShareQrCard to={shareFormPath} />
         </div>
       </CardSimple>
 

--- a/apps/web/src/lib/constants/catalog.ts
+++ b/apps/web/src/lib/constants/catalog.ts
@@ -91,3 +91,12 @@ export function getCatalogKindBySlug(
   if (!slug) return null;
   return CATALOG_KINDS[slug as CatalogKindSlug] ?? null;
 }
+
+export function getCatalogKindByKind(
+  kind: CatalogItemKind | undefined,
+): CatalogKindConfig | null {
+  if (!kind) return null;
+  return (
+    Object.values(CATALOG_KINDS).find((config) => config.kind === kind) ?? null
+  );
+}

--- a/apps/web/styles/user/profile.css
+++ b/apps/web/styles/user/profile.css
@@ -42,6 +42,51 @@
   animation: fadeIn 0.3s ease-out forwards;
 }
 
+/* Mini QR Code "animado" do atalho de compartilhar (dashboard): uma linha de
+   leitura desliza de cima a baixo sobre o código, simulando um scan. */
+@keyframes qrScan {
+  0% {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+  15% {
+    opacity: 1;
+  }
+  85% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(520%);
+    opacity: 0;
+  }
+}
+
+.qr-anim__scan {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 20%;
+  background: linear-gradient(
+    to bottom,
+    transparent,
+    color-mix(in srgb, var(--primary-color) 60%, transparent),
+    transparent
+  );
+  animation: qrScan 2.4s ease-in-out infinite;
+}
+
+.group:hover .qr-anim__scan {
+  animation-duration: 1.4s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .qr-anim__scan {
+    animation: none;
+    opacity: 0;
+  }
+}
+
 /* Buttons */
 .btn-primary {
   display: inline-flex;


### PR DESCRIPTION
2. "Ver feedbacks" — tirei o botão primário em destaque (era redundante com Feedbacks → Recebidos na navegação de cima). Deixei só um link de texto pequeno e discreto — assim some o destaque excessivo mas o atalho continua existindo (e o caso de uso CT-UC09-05 do e2e segue válido).

3. "Olá, nome" — tirei o ênfase exagerado e troquei o texto genérico por uma linha de status útil, montada com dados que o dashboard já carrega (sem fetch novo):

Sem feedbacks → "Compartilhe o formulário pelo QR Code para começar a coletar feedbacks." Com pendentes → "● N feedbacks aguardando análise neste escopo." Em dia → "Tudo em dia — nenhum feedback aguardando análise neste escopo."

3. "Olá, nome" — tirei o ênfase exagerado e troquei o texto genérico por uma linha de status útil, montada com dados que o dashboard já carrega (sem fetch novo):

Sem feedbacks → "Compartilhe o formulário pelo QR Code para começar a coletar feedbacks." Com pendentes → "● N feedbacks aguardando análise neste escopo." Em dia → "Tudo em dia — nenhum feedback aguardando análise neste escopo."

4. Compartilhar formulário — virou um mini QR Code animado (ShareQrCard.tsx) com uma linha de leitura deslizando sobre o código ("scan"), legenda "Utilize o QR Code" + subtítulo. Acelera no hover e respeita prefers-reduced-motion. Continua apontando para o destino correto conforme o escopo (o fix da conversa anterior).