### PR TITLE
feat(web): exibir faixa provável (intervalo de confiança) na média de estrelas do dashboard

### DIFF
--- a/apps/web/components/user/pages/dashboard/SectionMetric.tsx
+++ b/apps/web/components/user/pages/dashboard/SectionMetric.tsx
@@ -1,5 +1,7 @@
 import MetricCard from "components/user/shared/cards/MetricCard";
+import MetricHelp from "components/user/shared/MetricHelp";
 import FormatToCurrencyReal from "src/lib/utils/FormatToReal";
+import { formatInterval } from "src/lib/utils/statistics";
 import {
   FaComments,
   FaFrown,
@@ -8,7 +10,9 @@ import {
 } from 'react-icons/fa';
 import type { SectionMetricProps } from './ui.types';
 
-export default function SectionMetric({ totalFeedbacks, averageRating, positive, negative }: SectionMetricProps) {
+export default function SectionMetric({ totalFeedbacks, averageRating, positive, negative, starMeanCI }: SectionMetricProps) {
+  // Faixa provável (IC t da média de estrelas): só faz sentido com feedbacks no escopo.
+  const showRatingRange = starMeanCI != null && totalFeedbacks > 0;
 
   return (
     <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
@@ -18,7 +22,17 @@ export default function SectionMetric({ totalFeedbacks, averageRating, positive,
           minimumFractionDigits: 1,
           maximumFractionDigits: 1,
         })}
-        helper="Avaliação média em estrelas"
+        helper={
+          <>
+            Avaliação média em estrelas
+            {showRatingRange && (
+              <span className="mt-1 flex items-center gap-1">
+                faixa provável {formatInterval(starMeanCI, 1)}
+                <MetricHelp term="confidenceInterval" />
+              </span>
+            )}
+          </>
+        }
         icon={FaStar}
       />
       <MetricCard

--- a/apps/web/components/user/pages/dashboard/ui.types.ts
+++ b/apps/web/components/user/pages/dashboard/ui.types.ts
@@ -1,5 +1,5 @@
 import type { LoaderUserDashboard } from 'src/routes/loaders/loaderUserDashboard';
-import type { QuestionMetric } from 'lib/interfaces/domain/feedback.domain';
+import type { Interval, QuestionMetric } from 'lib/interfaces/domain/feedback.domain';
 
 /**
  * Props da seção de métricas principais do dashboard.
@@ -10,6 +10,8 @@ export interface SectionMetricProps {
   averageRating: number;
   positive: number;
   negative: number;
+  /** Faixa provável (IC t) da média de estrelas; ausente sem feedbacks no escopo. */
+  starMeanCI?: Interval | null;
 }
 
 /**

--- a/apps/web/components/user/shared/cards/ui.types.ts
+++ b/apps/web/components/user/shared/cards/ui.types.ts
@@ -8,7 +8,7 @@ import type { ReactNode } from 'react';
 export type MetricCardProps = {
   title: string;
   value: string;
-  helper?: string;
+  helper?: ReactNode;
   icon: IconType;
 };
 

--- a/apps/web/pages/user/dashboard.tsx
+++ b/apps/web/pages/user/dashboard.tsx
@@ -157,6 +157,7 @@ export default function Dashboard() {
             averageRating={averageRating}
             positive={positive}
             negative={negative}
+            starMeanCI={stats?.starMeanCI ?? null}
           />
 
           <div className="grid gap-6 lg:grid-cols-2">


### PR DESCRIPTION
- Altera a tipagem da propriedade `helper` em `MetricCardProps` de `string` para `ReactNode`, permitindo que os cards de métricas recebam elementos HTML ou componentes customizados.
- Atualiza o componente `SectionMetric` para receber e tratar o intervalo de confiança (`starMeanCI`) vindo das estatísticas do dashboard.
- Adiciona a exibição da "faixa provável" (formatada via `formatInterval`) com o componente de ajuda estatística `MetricHelp` na seção da média de estrelas, quando houver feedbacks no escopo.
- Conecta a propriedade `starMeanCI` com os dados estatísticos (`stats`) carregados na página principal do dashboard (`dashboard.tsx`).