### PR TITLE
test(web): tornar teste E2E do UC-04 resiliente com pontos de coleta reais

### DIFF
--- a/apps/web/e2e/fixtures/supabase-helpers.ts
+++ b/apps/web/e2e/fixtures/supabase-helpers.ts
@@ -56,3 +56,36 @@ export async function getEnterpriseIdByAuthUser(email: string): Promise<string |
   if (error || !data) return null;
   return data.id as string;
 }
+
+/**
+ * Resolve um ponto de coleta QR ATIVO da empresa para que o e2e use uma URL
+ * realista (`?enterprise=...&collection_point=...`). Prioriza o escopo empresa
+ * (`catalog_item_id IS NULL`) — o mesmo ponto que o submit exige. Retorna null
+ * quando a empresa não tem nenhum ponto QR ativo (config inconsistente no banco).
+ */
+export async function getActiveQrCollectionPoint(
+  enterpriseId: string,
+): Promise<{ id: string; catalogItemId: string | null } | null> {
+  const supabase = getAdminClient();
+  const { data, error } = await supabase
+    .from('collection_points')
+    .select('id, catalog_item_id')
+    .eq('enterprise_id', enterpriseId)
+    .eq('type', 'QR_CODE')
+    .eq('status', 'ACTIVE')
+    .order('catalog_item_id', { ascending: true, nullsFirst: true })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.warn('[supabase-helpers] getActiveQrCollectionPoint error:', error.message);
+    return null;
+  }
+
+  if (!data) return null;
+
+  return {
+    id: data.id as string,
+    catalogItemId: (data.catalog_item_id as string | null) ?? null,
+  };
+}

--- a/apps/web/e2e/uc-04-envio-feedback-qrcode.spec.ts
+++ b/apps/web/e2e/uc-04-envio-feedback-qrcode.spec.ts
@@ -1,22 +1,46 @@
 import { test, expect } from '@playwright/test';
 import { TEST_ENTERPRISE_ID, QR_FEEDBACK } from './fixtures/test-data';
-import { resetDeviceFingerprint } from './fixtures/supabase-helpers';
+import {
+  resetDeviceFingerprint,
+  getActiveQrCollectionPoint,
+} from './fixtures/supabase-helpers';
 
 test.use({ storageState: { cookies: [], origins: [] } });
 
-const QR_PATH = `/feedback/qrcode?enterprise=${TEST_ENTERPRISE_ID}`;
+const FEEDBACK_ENDPOINT = '/api/public/qrcode/feedback';
+
+// Resolvido no beforeAll: o submit exige um collection_point QR ativo, então a
+// URL precisa apontar para um real (e não só `?enterprise=...`, que o loader
+// aceita mas o submit recusa com 404).
+let qrCollectionPointId: string | null = null;
+let qrCatalogItemId: string | null = null;
+
+function buildQrPath(): string {
+  const params = new URLSearchParams({ enterprise: TEST_ENTERPRISE_ID });
+  if (qrCollectionPointId) params.set('collection_point', qrCollectionPointId);
+  if (qrCatalogItemId) params.set('item', qrCatalogItemId);
+  return `/feedback/qrcode?${params.toString()}`;
+}
 
 test.describe('UC-04: Envio de feedback via QR Code', () => {
   test.beforeAll(async () => {
-    if (TEST_ENTERPRISE_ID) {
-      await resetDeviceFingerprint(TEST_ENTERPRISE_ID);
+    if (!TEST_ENTERPRISE_ID) return;
+    await resetDeviceFingerprint(TEST_ENTERPRISE_ID);
+    const cp = await getActiveQrCollectionPoint(TEST_ENTERPRISE_ID);
+    if (cp) {
+      qrCollectionPointId = cp.id;
+      qrCatalogItemId = cp.catalogItemId;
     }
   });
 
   test('[CT-UC04-01] Envio válido exibe confirmação de feedback recebido', async ({ page }) => {
     test.skip(!TEST_ENTERPRISE_ID, 'E2E_TEST_ENTERPRISE_ID não configurado');
+    test.skip(
+      !qrCollectionPointId,
+      'Empresa de teste não possui collection_point QR ativo — verifique a config no homolog',
+    );
 
-    await page.goto(QR_PATH);
+    await page.goto(buildQrPath());
     await expect(page.getByRole('main')).toBeVisible();
     await page.waitForLoadState('networkidle');
 
@@ -39,7 +63,24 @@ test.describe('UC-04: Envio de feedback via QR Code', () => {
       await messageField.fill(QR_FEEDBACK.message);
     }
 
+    const responsePromise = page.waitForResponse(
+      (res) =>
+        res.url().includes(FEEDBACK_ENDPOINT) &&
+        res.request().method() === 'POST',
+      { timeout: 15_000 },
+    );
+
     await page.locator('button[type="submit"]').click();
+
+    // Captura o status real do submit: assim uma rejeição do servidor
+    // (404 sem collection_point, 400 por mismatch de perguntas, 5xx) falha com
+    // o motivo, em vez de estourar timeout em "elemento não encontrado".
+    const response = await responsePromise;
+    const body = await response.text().catch(() => '');
+    expect(
+      response.status(),
+      `POST ${FEEDBACK_ENDPOINT} retornou ${response.status()}: ${body}`,
+    ).toBe(200);
 
     await expect(
       page.getByText(/feedback enviado|obrigado|recebemos/i).first(),


### PR DESCRIPTION
- Adiciona a função utilitária `getActiveQrCollectionPoint` no `supabase-helpers.ts` para buscar um ponto de coleta QR ativo real no banco de dados para a empresa de teste.

- Atualiza o spec do UC-04 para construir dinamicamente a URL de feedback com os parâmetros reais `collection_point` e `item` obtidos no setup.

- Adiciona skip condicional no teste caso a empresa de teste não possua nenhum ponto QR ativo configurado no banco.

- Implementa monitoramento da requisição HTTP de submit (`POST /api/public/qrcode/feedback`) para capturar respostas de erro do servidor (ex: 404 ou 500) com mensagens descritivas em vez de falhar por timeout de elemento visual.