### PR TITLE
fix: resolver ponto de coleta geral e tratar QR Codes inativos no loader

### DIFF
--- a/apps/web/src/routes/load/loadPublicQrCodeEnterprise.test.ts
+++ b/apps/web/src/routes/load/loadPublicQrCodeEnterprise.test.ts
@@ -71,6 +71,34 @@ describe('[Integração] loadPublicQrCodeEnterpriseData', () => {
     });
   });
 
+  it('retorna erro amigável quando não há ponto de coleta ativo para o QR', async () => {
+    mockServiceGetEnterprisePublic.mockResolvedValue({
+      id: 'enterprise-1',
+      name: 'Empresa X',
+      collection_point_id: null,
+      catalog_item_id: null,
+      item_name: null,
+      item_kind: null,
+      questions: [],
+    });
+
+    const result = await loadPublicQrCodeEnterpriseData(
+      'http://localhost/feedback/qrcode?enterprise=enterprise-1',
+    );
+
+    expect(result).toEqual({
+      enterpriseId: null,
+      collectionPointId: null,
+      catalogItemId: null,
+      enterpriseName: '',
+      itemName: null,
+      itemKind: null,
+      questions: [],
+      error:
+        'QR Code indisponível: não há ponto de coleta ativo para este código. Verifique o QR Code ou contate a empresa.',
+    });
+  });
+
   it('retorna fallback amigável quando validação pública falha', async () => {
     mockServiceGetEnterprisePublic.mockRejectedValue(new Error('not found'));
 

--- a/apps/web/src/routes/load/loadPublicQrCodeEnterprise.ts
+++ b/apps/web/src/routes/load/loadPublicQrCodeEnterprise.ts
@@ -40,9 +40,29 @@ export async function loadPublicQrCodeEnterpriseData(
       catalogItemId,
     });
 
+    // O envio exige um collection_point QR ativo (resolvido pelo servidor). Sem
+    // ele, o submit retornaria 404. Não renderiza um formulário que nunca poderia
+    // ser enviado — mostra erro amigável (igual ao QR inválido), em vez de deixar
+    // o usuário preencher tudo para falhar no envio.
+    const resolvedCollectionPointId = enterprise.collection_point_id ?? null;
+
+    if (!resolvedCollectionPointId) {
+      return {
+        enterpriseId: null,
+        collectionPointId: null,
+        catalogItemId: null,
+        enterpriseName: '',
+        itemName: null,
+        itemKind: null,
+        questions: [],
+        error:
+          'QR Code indisponível: não há ponto de coleta ativo para este código. Verifique o QR Code ou contate a empresa.',
+      };
+    }
+
     return {
       enterpriseId,
-      collectionPointId: enterprise.collection_point_id ?? collectionPointId,
+      collectionPointId: resolvedCollectionPointId,
       catalogItemId: enterprise.catalog_item_id ?? catalogItemId,
       enterpriseName: enterprise.name || 'Empresa',
       itemName: enterprise.item_name ?? null,

--- a/backends/api-gateway/src/controllers/public/enterprise.controller.ts
+++ b/backends/api-gateway/src/controllers/public/enterprise.controller.ts
@@ -66,6 +66,23 @@ export async function getPublicEnterpriseController(req: Request, res: Response)
             ? contextItem.kind
             : null;
       }
+    } else {
+      // Escopo empresa (sem collection_point/item na URL): resolve o ponto de
+      // coleta QR "geral" (catalog_item_id IS NULL), que é EXATAMENTE o que o
+      // submit exige. Sem isso o endpoint devolvia collection_point_id: null e o
+      // formulário era renderizado sem destino válido — e o envio falhava 404.
+      const { data: companyCp } = await supabase
+        .from('collection_points')
+        .select('id')
+        .eq('enterprise_id', enterprise.id)
+        .eq('type', 'QR_CODE')
+        .eq('status', 'ACTIVE')
+        .is('catalog_item_id', null)
+        .maybeSingle();
+
+      if (companyCp) {
+        contextCollectionPointId = companyCp.id ?? null;
+      }
     }
 
     const currentScope: 'COMPANY' | 'PRODUCT' | 'SERVICE' | 'DEPARTMENT' =


### PR DESCRIPTION
- Backend (`enterprise.controller.ts`): Resolve o ponto de coleta QR geral (`catalog_item_id IS NULL` e ativo) quando nenhum parâmetro de escopo (`collection_point` ou `item`) for fornecido na URL pública da empresa. Isso evita que o formulário seja renderizado sem um ID de destino (o que gerava erro 404 no envio).

- Web Loader (`loadPublicQrCodeEnterprise.ts`): Adiciona validação no carregador de dados públicos para impedir a renderização do formulário caso o ponto de coleta resolvido seja nulo. Em vez de permitir o preenchimento de um formulário que falharia no envio, retorna um erro amigável ao usuário.

- Web Tests (`loadPublicQrCodeEnterprise.test.ts`): Adiciona teste de integração para validar o retorno do erro amigável quando a empresa não possui pontos de coleta QR ativos associados.

Resumo do impacto técnico:

1. Prevenção de Erros de Envio: O backend passa a identificar automaticamente o ponto de coleta QR geral correspondente à empresa caso não seja especificado na URL.

2. Melhoria da Experiência do Usuário (UX): Caso a empresa realmente não possua nenhum ponto de coleta QR ativo, o frontend barra o preenchimento logo no carregamento com uma mensagem instrutiva de indisponibilidade, em vez de deixar o usuário digitar e falhar apenas no clique de submit.