### PR TITLE
docs: corrige motivação da separação — também foi técnica (ORM×RLS)

### DIFF
--- a/docs/arquitetura/historico-de-decisoes/decisao-monorepo-vs-monolito.md
+++ b/docs/arquitetura/historico-de-decisoes/decisao-monorepo-vs-monolito.md
@@ -149,7 +149,10 @@ No monolito, esse cenário seria crítico: 10 análises simultâneas significari
 
 ## Evolução: de Monorepo para Multi-repo
 
-**Decisão de jul/2026.** O código, antes co-localizado em um monorepo (npm Workspaces), foi separado em **repositórios independentes** — um por serviço, mais um repositório para os contratos e este para a documentação. A motivação foi **organizacional**, não técnica: permitir **isolamento de acesso por repositório** (contribuidores com menos experiência atuam só no frontend, sem acesso ao restante) e **históricos + CI independentes** por serviço.
+**Decisão de jul/2026.** O código, antes co-localizado em um monorepo (npm Workspaces), foi separado em **repositórios independentes** — um por serviço, mais um repositório para os contratos e este para a documentação. A motivação foi **organizacional e técnica**:
+
+- **Organizacional:** **isolamento de acesso por repositório** (contribuidores com menos experiência atuam só no frontend, sem acesso ao restante) e **históricos + CI independentes** por serviço.
+- **Técnica — segurança e qualidade no acesso a dados:** com a entrada do **ORM (Drizzle)** nos caminhos autenticados, a conexão passa a ser **direta ao Postgres** (via `DATABASE_URL`/pooler), e essa conexão **não é filtrada pela RLS** — ou seja, **a RLS deixa de proteger automaticamente onde o ORM entra**. O isolamento por empresa (tenant) passa a exigir **filtro explícito por `enterprise_id` na aplicação** (a RLS permanece ligada como *defesa em profundidade*, não como guarda principal desse caminho). Isso eleva o cuidado exigido no acesso ao banco: **separar esse código sensível no seu próprio repositório** (`feedback-analytics-api-gateway`), longe do frontend, **concentra a atenção e a revisão** onde a segurança é crítica e reduz o raio de impacto de um erro. Ver [ORM × RLS: nossa decisão](../orm-rls-decisao.md).
 
 ### O que permaneceu e o que mudou
 

--- a/proximos-passos/README.md
+++ b/proximos-passos/README.md
@@ -86,7 +86,7 @@ O risco de um TCC parecer "duas listas soltas" (refatorações + funcionalidades
 |---|---|---|
 | **Autenticação própria?** | Manter Supabase Auth (recomendado, menor risco) **ou** biblioteca de auth self-hosted (só se formos para servidor próprio total) | [07](./07-seguranca-e-lgpd.md) e [08](./08-infraestrutura-e-custo.md) |
 | **Self-host total?** | "Mínimo" (fica no Supabase, move só o worker) **ou** "tudo num servidor próprio" (mais esforço, mais demonstração) | [08](./08-infraestrutura-e-custo.md) |
-| **Separar os repositórios?** | ✅ **Decidido (jul/2026): separado em multi-repo.** A motivação foi organizacional (isolar acesso por repositório para novos contribuidores); a sincronização de contratos passou a um pacote versionado (`@feedback/lib-shared`). Ver [decisão de arquitetura](../docs/arquitetura/historico-de-decisoes/decisao-monorepo-vs-monolito.md#evolução-de-monorepo-para-multi-repo). | [08](./08-infraestrutura-e-custo.md) |
+| **Separar os repositórios?** | ✅ **Decidido (jul/2026): separado em multi-repo.** Motivação **organizacional e técnica**: isolar acesso por repositório para novos contribuidores; e, como o **ORM (Drizzle) bypassa a RLS** (a segurança passa a depender de filtro explícito por `enterprise_id` na aplicação), concentrar o código sensível de acesso ao banco no repo do gateway para revisão mais atenta. A sincronização de contratos passou a um pacote versionado (`@feedback/lib-shared`). Ver [decisão de arquitetura](../docs/arquitetura/historico-de-decisoes/decisao-monorepo-vs-monolito.md#evolução-de-monorepo-para-multi-repo) e [ORM × RLS](../docs/arquitetura/orm-rls-decisao.md). | [08](./08-infraestrutura-e-custo.md) |
 
 ## Alerta honesto de escopo
 


### PR DESCRIPTION
A separação em multi-repo não foi só organizacional: com o ORM (Drizzle) nos caminhos autenticados, a conexão direta ao Postgres bypassa a RLS, então a segurança passa a exigir filtro explícito por enterprise_id na aplicação. Separar o código sensível de acesso ao banco no repo do gateway concentra atenção/revisão onde a segurança é crítica (RLS segue como defesa em profundidade). Atualiza o ADR de evolução e a decisão no roadmap; linka o doc ORM × RLS.