### PR TITLE
ci(docs): bump das GitHub Pages actions para Node 24

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: pip
@@ -45,7 +45,7 @@ jobs:
         run: mkdocs build --strict
 
       - name: Upload do artefato do Pages
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy no GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## O que
Remove o aviso de **deprecação do Node 20** nos runners do GitHub Actions, no workflow `deploy-docs.yml` (o que publica o site MkDocs no GitHub Pages).

O aviso citava `actions/deploy-pages@v4`, mas na verificação **três** actions JS estavam em Node 20 (a mensagem do runner estava truncada). Bump para as versões em **Node 24**:

| Action | De | Para |
|---|---|---|
| `actions/checkout` | v4 (node20) | **v5** (node24) |
| `actions/setup-python` | v5 (node20) | **v6** (node24) |
| `actions/upload-pages-artifact` | v3 (node20 via upload-artifact@v4) | **v5** (node24) |
| `actions/deploy-pages` | v4 (node20) ← *a citada no aviso* | **v5** (node24) |

## Notas
- Runtime de cada versão-alvo **verificado** (`action.yml` → `using: node24`).
- `upload-pages-artifact` e `deploy-pages` ficam no **par v5** (formato de artefato compatível).
- Sem mudança de comportamento: mesmos inputs (`python-version`, `cache`, `path: site`); build segue `mkdocs build --strict`.
- É o único workflow do repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)